### PR TITLE
Query broker config map

### DIFF
--- a/k8s/vizier/base/default_role.yaml
+++ b/k8s/vizier/base/default_role.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: pl-vizier-crd-binding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: pl-vizier-crd-role
+subjects:
+  - kind: ServiceAccount
+    name: default

--- a/k8s/vizier/base/kustomization.yaml
+++ b/k8s/vizier/base/kustomization.yaml
@@ -21,6 +21,7 @@ patches:
     kind: StatefulSet
 resources:
 - ../bootstrap
+- default_role.yaml
 - kelvin_deployment.yaml
 - kelvin_service.yaml
 - metadata_role.yaml

--- a/k8s/vizier/base/query_broker_deployment.yaml
+++ b/k8s/vizier/base/query_broker_deployment.yaml
@@ -105,6 +105,7 @@ spec:
             - ALL
           seccompProfile:
             type: RuntimeDefault
+      serviceAccountName: query-broker-service-account
       securityContext:
         runAsUser: 10100
         runAsGroup: 10100

--- a/k8s/vizier/base/query_broker_role.yaml
+++ b/k8s/vizier/base/query_broker_role.yaml
@@ -1,13 +1,44 @@
 ---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: query-broker-service-account
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  creationTimestamp: null
+  name: pl-vizier-query-broker-role
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+    verbs:
+      - get
+      - list
+      - watch
+---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: pl-vizier-crd-binding
+  name: pl-vizier-query-broker-crd-binding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
   name: pl-vizier-crd-role
 subjects:
 - kind: ServiceAccount
-  name: default
-  namespace: pl
+  name: query-broker-service-account
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: pl-vizier-query-broker-binding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: pl-vizier-query-broker-role
+subjects:
+  - kind: ServiceAccount
+    name: query-broker-service-account

--- a/src/utils/template_generator/vizier_yamls/vizier_yamls.go
+++ b/src/utils/template_generator/vizier_yamls/vizier_yamls.go
@@ -413,6 +413,18 @@ func generateVzYAMLs(yamlMap map[string]string) ([]*yamls.YAMLFile, error) {
 			TemplateValue:   nsTmpl,
 		},
 		{
+			TemplateMatcher: yamls.GenerateResourceNameMatcherFn("pl-vizier-query-broker-crd-binding"),
+			Patch:           `{ "subjects": [{ "name": "query-broker-service-account", "namespace": "__PX_SUBJECT_NAMESPACE__", "kind": "ServiceAccount" }] }`,
+			Placeholder:     "__PX_SUBJECT_NAMESPACE__",
+			TemplateValue:   nsTmpl,
+		},
+		{
+			TemplateMatcher: yamls.GenerateResourceNameMatcherFn("pl-vizier-query-broker-binding"),
+			Patch:           `{ "subjects": [{ "name": "query-broker-service-account", "namespace": "__PX_SUBJECT_NAMESPACE__", "kind": "ServiceAccount" }] }`,
+			Placeholder:     "__PX_SUBJECT_NAMESPACE__",
+			TemplateValue:   nsTmpl,
+		},
+		{
 			TemplateMatcher: yamls.GenerateResourceNameMatcherFn("pl-vizier-metadata-node-view-cluster-binding"),
 			Patch:           `{ "subjects": [{ "name": "metadata-service-account", "namespace": "__PX_SUBJECT_NAMESPACE__", "kind": "ServiceAccount" }] }`,
 			Placeholder:     "__PX_SUBJECT_NAMESPACE__",

--- a/src/vizier/services/query_broker/controllers/query_executor.go
+++ b/src/vizier/services/query_broker/controllers/query_executor.go
@@ -508,7 +508,7 @@ func (q *QueryExecutorImpl) prepareScript(ctx context.Context, resultCh chan<- *
 func (q *QueryExecutorImpl) runScript(ctx context.Context, resultCh chan<- *vizierpb.ExecuteScriptResponse, req *vizierpb.ExecuteScriptRequest) error {
 	defer close(resultCh)
 	q.startTime = time.Now()
-	log.WithField("query_id", q.queryID).Infof("Running script")
+	log.WithField("query_id", q.queryID).WithField("query_name", q.queryName).Infof("Running script")
 
 	if req.QueryID == "" {
 		if err := q.prepareScript(ctx, resultCh, req); err != nil {

--- a/src/vizier/services/query_broker/query_broker_server.go
+++ b/src/vizier/services/query_broker/query_broker_server.go
@@ -32,7 +32,6 @@ import (
 	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
 	"google.golang.org/grpc"
-
 	"px.dev/pixie/src/api/proto/vizierpb"
 	"px.dev/pixie/src/carnot/carnotpb"
 	"px.dev/pixie/src/shared/services"
@@ -59,6 +58,7 @@ func init() {
 	pflag.String("mds_service", "vizier-metadata-svc", "The metadata service name")
 	pflag.String("mds_port", "50400", "The querybroker service port")
 	pflag.String("pod_namespace", "pl", "The namespace this pod runs in.")
+	pflag.StringArray("cron_script_sources", scriptrunner.DefaultSources, "Where to find cron scripts (cloud, configmaps)")
 }
 
 // NewVizierServiceClient creates a new vz RPC client stub.
@@ -206,10 +206,14 @@ func main() {
 	defer ptProxy.Close()
 
 	// Start cron script runner.
-	sr, err := scriptrunner.New(natsConn, csClient, vzServiceClient, viper.GetString("jwt_signing_key"))
-	if err != nil {
-		log.WithError(err).Fatal("Failed to start script runner")
-	}
+	sources := scriptrunner.Sources(
+		natsConn,
+		csClient,
+		viper.GetString("jwt_signing_key"),
+		viper.GetString("pod_namespace"),
+		viper.GetStringSlice("cron_script_sources"),
+	)
+	sr := scriptrunner.New(csClient, vzServiceClient, viper.GetString("jwt_signing_key"), sources...)
 
 	// Load the scripts and start the background sync.
 	go func() {
@@ -218,6 +222,7 @@ func main() {
 			log.WithError(err).Error("Failed to sync cron scripts")
 		}
 	}()
+
 	s.Start()
 	s.StopOnInterrupt()
 }

--- a/src/vizier/services/query_broker/script_runner/BUILD.bazel
+++ b/src/vizier/services/query_broker/script_runner/BUILD.bazel
@@ -19,7 +19,7 @@ load("//bazel:pl_build_system.bzl", "pl_go_test")
 
 go_library(
     name = "script_runner",
-    srcs = ["script_runner.go"],
+    srcs = ["script_runner.go", "script_source.go", "config_map_source.go", "cloud_source.go"],
     importpath = "px.dev/pixie/src/vizier/services/query_broker/script_runner",
     visibility = ["//visibility:public"],
     deps = [
@@ -31,6 +31,7 @@ go_library(
         "//src/shared/scripts",
         "//src/shared/services/utils",
         "//src/utils",
+        "//src/utils/shared/k8s",
         "//src/vizier/services/metadata/metadatapb:service_pl_go_proto",
         "//src/vizier/utils/messagebus",
         "@com_github_gofrs_uuid//:uuid",
@@ -42,15 +43,22 @@ go_library(
         "@org_golang_google_grpc//codes",
         "@org_golang_google_grpc//metadata",
         "@org_golang_google_grpc//status",
+        "@io_k8s_api//core/v1:core",
+        "@io_k8s_apimachinery//pkg/apis/meta/v1:meta",
+        "@io_k8s_apimachinery//pkg/watch",
+        "@io_k8s_client_go//kubernetes",
+        "@io_k8s_client_go//kubernetes/typed/core/v1:core",
+        "@io_k8s_client_go//rest",
     ],
 )
 
 pl_go_test(
     name = "script_runner_test",
-    srcs = ["script_runner_test.go"],
+    srcs = ["script_runner_test.go", "config_map_source_test.go", "cloud_source_test.go", "helper_test.go"],
     embed = [":script_runner"],
     deps = [
         "//src/api/proto/vizierpb:vizier_pl_go_proto",
+        "//src/api/proto/vizierpb/mock",
         "//src/carnot/planner/compilerpb:compiler_status_pl_go_proto",
         "//src/common/base/statuspb:status_pl_go_proto",
         "//src/shared/cvmsgspb:cvmsgs_pl_go_proto",
@@ -67,5 +75,10 @@ pl_go_test(
         "@org_golang_google_grpc//:go_default_library",
         "@org_golang_google_grpc//codes",
         "@org_golang_google_grpc//status",
+        "@com_github_golang_mock//gomock",
+        "@io_k8s_apimachinery//pkg/labels",
+        "@io_k8s_apimachinery//pkg/runtime",
+        "@io_k8s_client_go//kubernetes/fake",
+        "@io_k8s_client_go//testing",
     ],
 )

--- a/src/vizier/services/query_broker/script_runner/cloud_source.go
+++ b/src/vizier/services/query_broker/script_runner/cloud_source.go
@@ -1,0 +1,242 @@
+/*
+ * Copyright 2018- The Pixie Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package scriptrunner
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/gofrs/uuid"
+	"github.com/gogo/protobuf/proto"
+	"github.com/gogo/protobuf/types"
+	"github.com/nats-io/nats.go"
+	log "github.com/sirupsen/logrus"
+	"google.golang.org/grpc/metadata"
+	"px.dev/pixie/src/shared/cvmsgspb"
+	"px.dev/pixie/src/shared/scripts"
+	svcutils "px.dev/pixie/src/shared/services/utils"
+	"px.dev/pixie/src/vizier/services/metadata/metadatapb"
+)
+
+// CloudSource constructs a [Source] that will pull cron scripts from the control plane
+func CloudSource(nc *nats.Conn, csClient metadatapb.CronScriptStoreServiceClient, signingKey string) Source {
+	return func(baseCtx context.Context, updateCb func(*cvmsgspb.CronScriptUpdate)) (map[string]*cvmsgspb.CronScript, func(), error) {
+		ctx := metadata.AppendToOutgoingContext(baseCtx,
+			"authorization", fmt.Sprintf("bearer %s", cronScriptStoreToken(signingKey)),
+		)
+		sub, err := nc.Subscribe(CronScriptUpdatesChannel, natsUpdater(ctx, nc, csClient, updateCb))
+		unsubscribe := func() {
+			if err := sub.Unsubscribe(); err != nil {
+				log.WithError(err).Error("could not unsubscribe from cloud cron script updates")
+			}
+		}
+		initialScripts, err := fetchInitialScripts(ctx, nc, csClient)
+		if err != nil {
+			unsubscribe()
+			return nil, nil, err
+		}
+		return initialScripts, unsubscribe, nil
+	}
+}
+
+func cronScriptStoreToken(signingKey string) string {
+	claims := svcutils.GenerateJWTForService("cron_script_store", "vizier")
+	token, _ := svcutils.SignJWTClaims(claims, signingKey)
+	return token
+}
+
+func natsUpdater(ctx context.Context, nc *nats.Conn, csClient metadatapb.CronScriptStoreServiceClient, updateCb func(*cvmsgspb.CronScriptUpdate)) func(msg *nats.Msg) {
+	return func(msg *nats.Msg) {
+		var cronScriptUpdate cvmsgspb.CronScriptUpdate
+		if err := unmarshalC2V(msg, &cronScriptUpdate); err != nil {
+			log.WithError(err).Error("Failed to unmarshal c2v message")
+			return
+		}
+
+		updateCb(&cronScriptUpdate)
+
+		switch cronScriptUpdate.Msg.(type) {
+		case *cvmsgspb.CronScriptUpdate_UpsertReq:
+			upsertReq := cronScriptUpdate.GetUpsertReq()
+			_, err := csClient.AddOrUpdateScript(ctx, &metadatapb.AddOrUpdateScriptRequest{Script: upsertReq.Script})
+			if err != nil {
+				log.WithError(err).Error("Failed to upsert script in metadata")
+			}
+
+			// Send response.
+			data, err := marshalV2C(&cvmsgspb.RegisterOrUpdateCronScriptResponse{})
+			if err != nil {
+				log.WithError(err).Error("Failed to marshal update script response")
+				return
+			}
+			err = nc.Publish(fmt.Sprintf("%s:%s", CronScriptUpdatesResponseChannel, cronScriptUpdate.RequestID), data)
+			if err != nil {
+				log.WithError(err).Error("Failed to publish update script response")
+			}
+		case *cvmsgspb.CronScriptUpdate_DeleteReq:
+			deleteReq := cronScriptUpdate.GetDeleteReq()
+			_, err := csClient.DeleteScript(ctx, &metadatapb.DeleteScriptRequest{ScriptID: deleteReq.ScriptID})
+			if err != nil {
+				log.WithError(err).Error("Failed to delete script from metadata")
+			}
+
+			// Send response.
+			data, err := marshalV2C(&cvmsgspb.DeleteCronScriptResponse{})
+			if err != nil {
+				log.WithError(err).Error("Failed to marshal update script response")
+				return
+			}
+			if err != nil {
+				log.WithError(err).Error("Failed to marshal update script response")
+				return
+			}
+			err = nc.Publish(fmt.Sprintf("%s:%s", CronScriptUpdatesResponseChannel, cronScriptUpdate.RequestID), data)
+			if err != nil {
+				log.WithError(err).Error("Failed to publish update script response")
+			}
+		default:
+			log.Error("Received unknown message for cronScriptUpdate")
+		}
+	}
+}
+
+func unmarshalC2V[T proto.Message](msg *nats.Msg, msgBody T) error {
+	c2vMsg := &cvmsgspb.C2VMessage{}
+	err := proto.Unmarshal(msg.Data, c2vMsg)
+	if err != nil {
+		return err
+	}
+	err = types.UnmarshalAny(c2vMsg.Msg, msgBody)
+	if err != nil {
+		return err
+	}
+	return err
+}
+
+func marshalV2C[T proto.Message](msg T) ([]byte, error) {
+	msgBody, err := types.MarshalAny(msg)
+	if err != nil {
+		return nil, err
+	}
+	v2cMsg := &cvmsgspb.V2CMessage{Msg: msgBody}
+	return v2cMsg.Marshal()
+}
+
+func fetchInitialScripts(ctx context.Context, nc *nats.Conn, csClient metadatapb.CronScriptStoreServiceClient) (map[string]*cvmsgspb.CronScript, error) {
+	resp, err := csClient.GetScripts(ctx, &metadatapb.GetScriptsRequest{})
+	if err != nil {
+		log.WithError(err).Error("Failed to fetch initialScripts from store")
+		return nil, err
+	}
+	initialScripts := resp.Scripts
+
+	// Check if persisted initialScripts are up-to-date.
+	upToDate, err := compareScriptState(ctx, nc, initialScripts)
+	if err != nil {
+		// In the case there is a failure, we should just refetch the initialScripts.
+		log.WithError(err).Error("Failed to verify script checksum")
+	}
+
+	// If hash is not equal, fetch initialScripts from cloud.
+	if !upToDate {
+		cloudScripts, err := getCloudScripts(ctx, nc)
+		if err != nil {
+			log.WithError(err).Error("Failed to fetch initialScripts from cloud")
+		} else {
+			// Clear out persisted initialScripts.
+			_, err = csClient.SetScripts(ctx, &metadatapb.SetScriptsRequest{Scripts: make(map[string]*cvmsgspb.CronScript)})
+			if err != nil {
+				log.WithError(err).Error("Failed to delete initialScripts from store")
+				return nil, err
+			}
+			initialScripts = cloudScripts
+		}
+	}
+	return initialScripts, nil
+}
+
+func compareScriptState(ctx context.Context, nc *nats.Conn, existingScripts map[string]*cvmsgspb.CronScript) (bool, error) {
+	// Get hash of map.
+	existingChecksum, err := scripts.ChecksumFromScriptMap(existingScripts)
+	if err != nil {
+		return false, err
+	}
+
+	topicID := uuid.Must(uuid.NewV4())
+	req := &cvmsgspb.GetCronScriptsChecksumRequest{
+		Topic: topicID.String(),
+	}
+	res := &cvmsgspb.GetCronScriptsChecksumResponse{}
+	err = natsReplyAndResponse(ctx, nc, req, CronScriptChecksumRequestChannel, res, fmt.Sprintf("%s:%s", CronScriptChecksumResponseChannel, topicID.String()))
+	if err != nil {
+		return false, err
+	}
+	return existingChecksum == res.Checksum, nil
+}
+
+func natsReplyAndResponse(ctx context.Context, nc *nats.Conn, req proto.Message, requestTopic string, res proto.Message, responseTopic string) error {
+	// Subscribe to topic that the response will be sent on.
+	subCh := make(chan *nats.Msg, 4096)
+	sub, err := nc.ChanSubscribe(responseTopic, subCh)
+	if err != nil {
+		return err
+	}
+	defer sub.Unsubscribe()
+
+	// Publish request.
+	reqData, err := marshalV2C(req)
+	if err != nil {
+		return err
+	}
+	err = nc.Publish(requestTopic, reqData)
+	if err != nil {
+		return err
+	}
+
+	// Wait for response.
+	t := time.NewTimer(natsWaitTimeout)
+	defer t.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return errors.New("Cancelled")
+		case msg := <-subCh:
+			if err := unmarshalC2V(msg, res); err != nil {
+				log.WithError(err).Error("Failed to unmarshal checksum response")
+				return err
+			}
+			return nil
+		case <-t.C:
+			return errors.New("Failed to get response")
+		}
+	}
+}
+
+func getCloudScripts(ctx context.Context, nc *nats.Conn) (map[string]*cvmsgspb.CronScript, error) {
+	topicID := uuid.Must(uuid.NewV4())
+	req := &cvmsgspb.GetCronScriptsRequest{Topic: topicID.String()}
+	res := &cvmsgspb.GetCronScriptsResponse{}
+	err := natsReplyAndResponse(ctx, nc, req, GetCronScriptsRequestChannel, res, fmt.Sprintf("%s:%s", GetCronScriptsResponseChannel, topicID.String()))
+	if err != nil {
+		return nil, err
+	}
+	return res.Scripts, nil
+}

--- a/src/vizier/services/query_broker/script_runner/cloud_source_test.go
+++ b/src/vizier/services/query_broker/script_runner/cloud_source_test.go
@@ -1,0 +1,690 @@
+/*
+ * Copyright 2018- The Pixie Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package scriptrunner
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/gofrs/uuid"
+	"github.com/gogo/protobuf/proto"
+	"github.com/gogo/protobuf/types"
+	"github.com/nats-io/nats.go"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"px.dev/pixie/src/shared/cvmsgspb"
+	"px.dev/pixie/src/shared/scripts"
+	"px.dev/pixie/src/utils"
+	"px.dev/pixie/src/utils/testingutils"
+	"px.dev/pixie/src/vizier/services/metadata/metadatapb"
+)
+
+func TestCloudScriptsSource_InitialState(t *testing.T) {
+	tests := []struct {
+		name             string
+		persistedScripts map[string]*cvmsgspb.CronScript
+		cloudScripts     map[string]*cvmsgspb.CronScript
+		checksumMatch    bool
+	}{
+		{
+			name: "checksums match",
+			persistedScripts: map[string]*cvmsgspb.CronScript{
+				"223e4567-e89b-12d3-a456-426655440000": {
+					ID:         utils.ProtoFromUUIDStrOrNil("223e4567-e89b-12d3-a456-426655440000"),
+					Script:     "px.display()",
+					Configs:    "config1",
+					FrequencyS: 5,
+				},
+				"223e4567-e89b-12d3-a456-426655440001": {
+					ID:         utils.ProtoFromUUIDStrOrNil("223e4567-e89b-12d3-a456-426655440001"),
+					Script:     "test script",
+					Configs:    "config2",
+					FrequencyS: 22,
+				},
+			},
+			cloudScripts: map[string]*cvmsgspb.CronScript{
+				"223e4567-e89b-12d3-a456-426655440000": {
+					ID:         utils.ProtoFromUUIDStrOrNil("223e4567-e89b-12d3-a456-426655440000"),
+					Script:     "px.display()",
+					Configs:    "config1",
+					FrequencyS: 5,
+				},
+				"223e4567-e89b-12d3-a456-426655440001": {
+					ID:         utils.ProtoFromUUIDStrOrNil("223e4567-e89b-12d3-a456-426655440001"),
+					Script:     "test script",
+					Configs:    "config2",
+					FrequencyS: 22,
+				},
+			},
+			checksumMatch: true,
+		},
+		{
+			name: "checksums mismatch: one field different",
+			persistedScripts: map[string]*cvmsgspb.CronScript{
+				"223e4567-e89b-12d3-a456-426655440000": {
+					ID:         utils.ProtoFromUUIDStrOrNil("223e4567-e89b-12d3-a456-426655440000"),
+					Script:     "px.display()",
+					Configs:    "config1",
+					FrequencyS: 5,
+				},
+				"223e4567-e89b-12d3-a456-426655440001": {
+					ID:         utils.ProtoFromUUIDStrOrNil("223e4567-e89b-12d3-a456-426655440001"),
+					Script:     "test script",
+					Configs:    "config2",
+					FrequencyS: 22,
+				},
+			},
+			cloudScripts: map[string]*cvmsgspb.CronScript{
+				"223e4567-e89b-12d3-a456-426655440000": {
+					ID:         utils.ProtoFromUUIDStrOrNil("223e4567-e89b-12d3-a456-426655440000"),
+					Script:     "px.display()",
+					Configs:    "config1",
+					FrequencyS: 6,
+				},
+				"223e4567-e89b-12d3-a456-426655440001": {
+					ID:         utils.ProtoFromUUIDStrOrNil("223e4567-e89b-12d3-a456-426655440001"),
+					Script:     "test script",
+					Configs:    "config2",
+					FrequencyS: 22,
+				},
+			},
+			checksumMatch: false,
+		},
+		{
+			name: "checksums mismatch: missing script",
+			persistedScripts: map[string]*cvmsgspb.CronScript{
+				"223e4567-e89b-12d3-a456-426655440000": {
+					ID:         utils.ProtoFromUUIDStrOrNil("223e4567-e89b-12d3-a456-426655440000"),
+					Script:     "px.display()",
+					Configs:    "config1",
+					FrequencyS: 5,
+				},
+				"223e4567-e89b-12d3-a456-426655440001": {
+					ID:         utils.ProtoFromUUIDStrOrNil("223e4567-e89b-12d3-a456-426655440001"),
+					Script:     "test script",
+					Configs:    "config2",
+					FrequencyS: 22,
+				},
+			},
+			cloudScripts: map[string]*cvmsgspb.CronScript{
+				"223e4567-e89b-12d3-a456-426655440000": {
+					ID:         utils.ProtoFromUUIDStrOrNil("223e4567-e89b-12d3-a456-426655440000"),
+					Script:     "px.display()",
+					Configs:    "config1",
+					FrequencyS: 6,
+				},
+			},
+			checksumMatch: false,
+		},
+		{
+			name:             "checksums match: empty",
+			persistedScripts: map[string]*cvmsgspb.CronScript{},
+			cloudScripts:     map[string]*cvmsgspb.CronScript{},
+			checksumMatch:    true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			nc, natsCleanup := testingutils.MustStartTestNATS(t)
+			defer natsCleanup()
+			persistedScripts := map[uuid.UUID]*cvmsgspb.CronScript{}
+			for id, script := range test.persistedScripts {
+				persistedScripts[uuid.Must(uuid.FromString(id))] = script
+			}
+			fcs := &fakeCronStore{scripts: persistedScripts}
+
+			cloudScripts := test.cloudScripts
+			checksumSub, _ := setupChecksumSubscription(t, nc, cloudScripts)
+			defer func() {
+				require.NoError(t, checksumSub.Unsubscribe())
+			}()
+
+			scriptSub, gotCronScripts := setupCloudScriptsSubscription(t, nc, cloudScripts)
+			defer func() {
+				require.NoError(t, scriptSub.Unsubscribe())
+			}()
+
+			_, stop, err := CloudSource(nc, fcs, "test")(context.Background(), dummyUpdateCb())
+			require.NoError(t, err)
+			defer stop()
+
+			select {
+			case <-gotCronScripts:
+				if test.checksumMatch {
+					t.Fatal("should not have fetched cron scripts")
+				}
+			case <-time.After(time.Millisecond):
+				if !test.checksumMatch {
+					t.Fatal("should have fetched cron scripts")
+				}
+			}
+		})
+	}
+
+	t.Run("does not receive updates after the metadata store fails to fetch the initial state", func(t *testing.T) {
+		nc, natsCleanup := testingutils.MustStartTestNATS(t)
+		defer natsCleanup()
+		scs := &stubCronScriptStore{GetScriptsError: errors.New("failed to get scripts")}
+
+		checksumSub, _ := setupChecksumSubscription(t, nc, nil)
+		defer func() {
+			require.NoError(t, checksumSub.Unsubscribe())
+		}()
+
+		sentUpdates := []*cvmsgspb.CronScriptUpdate{
+			{
+				Msg: &cvmsgspb.CronScriptUpdate_UpsertReq{
+					UpsertReq: &cvmsgspb.RegisterOrUpdateCronScriptRequest{
+						Script: &cvmsgspb.CronScript{
+							ID:         utils.ProtoFromUUIDStrOrNil("223e4567-e89b-12d3-a456-426655440002"),
+							Script:     "test script 1",
+							Configs:    "config1",
+							FrequencyS: 123,
+						},
+					},
+				},
+				RequestID: "1",
+				Timestamp: 1,
+			},
+		}
+		cronScriptResSubs, gotCronScriptResponses := setupCronScriptResponses(t, nc, sentUpdates)
+		defer func() {
+			for _, sub := range cronScriptResSubs {
+				require.NoError(t, sub.Unsubscribe())
+			}
+		}()
+
+		updateCb, updatesCh := mockUpdateCb()
+		_, _, err := CloudSource(nc, scs, "test")(context.Background(), updateCb)
+		require.Error(t, err)
+
+		sendUpdates(t, nc, sentUpdates)
+
+		requireNoReceive(t, updatesCh, time.Millisecond)
+		for _, getCronScriptResponse := range gotCronScriptResponses {
+			requireNoReceive(t, getCronScriptResponse, time.Millisecond)
+		}
+	})
+
+	t.Run("does not receive updates after the metadata store fails to save the initial state", func(t *testing.T) {
+		persistedScripts := map[string]*cvmsgspb.CronScript{
+			"223e4567-e89b-12d3-a456-426655440000": {
+				ID:         utils.ProtoFromUUIDStrOrNil("223e4567-e89b-12d3-a456-426655440000"),
+				Script:     "px.display()",
+				Configs:    "config1",
+				FrequencyS: 5,
+			},
+			"223e4567-e89b-12d3-a456-426655440001": {
+				ID:         utils.ProtoFromUUIDStrOrNil("223e4567-e89b-12d3-a456-426655440001"),
+				Script:     "test script",
+				Configs:    "config2",
+				FrequencyS: 22,
+			},
+		}
+		cloudScripts := map[string]*cvmsgspb.CronScript{
+			"223e4567-e89b-12d3-a456-426655440000": {
+				ID:         utils.ProtoFromUUIDStrOrNil("223e4567-e89b-12d3-a456-426655440000"),
+				Script:     "px.display()",
+				Configs:    "config1",
+				FrequencyS: 6,
+			},
+			"223e4567-e89b-12d3-a456-426655440001": {
+				ID:         utils.ProtoFromUUIDStrOrNil("223e4567-e89b-12d3-a456-426655440001"),
+				Script:     "test script",
+				Configs:    "config2",
+				FrequencyS: 22,
+			},
+		}
+		nc, natsCleanup := testingutils.MustStartTestNATS(t)
+		defer natsCleanup()
+		scs := &stubCronScriptStore{
+			GetScriptsResponse: &metadatapb.GetScriptsResponse{Scripts: persistedScripts},
+			SetScriptsError:    errors.New("could not save scripts"),
+		}
+
+		checksumSub, _ := setupChecksumSubscription(t, nc, cloudScripts)
+		defer func() {
+			require.NoError(t, checksumSub.Unsubscribe())
+		}()
+
+		scriptSub, _ := setupCloudScriptsSubscription(t, nc, cloudScripts)
+		defer func() {
+			require.NoError(t, scriptSub.Unsubscribe())
+		}()
+
+		sentUpdates := []*cvmsgspb.CronScriptUpdate{
+			{
+				Msg: &cvmsgspb.CronScriptUpdate_UpsertReq{
+					UpsertReq: &cvmsgspb.RegisterOrUpdateCronScriptRequest{
+						Script: &cvmsgspb.CronScript{
+							ID:         utils.ProtoFromUUIDStrOrNil("223e4567-e89b-12d3-a456-426655440002"),
+							Script:     "test script 1",
+							Configs:    "config1",
+							FrequencyS: 123,
+						},
+					},
+				},
+				RequestID: "1",
+				Timestamp: 1,
+			},
+		}
+		cronScriptResSubs, gotCronScriptResponses := setupCronScriptResponses(t, nc, sentUpdates)
+		defer func() {
+			for _, sub := range cronScriptResSubs {
+				require.NoError(t, sub.Unsubscribe())
+			}
+		}()
+
+		updateCb, updatesCh := mockUpdateCb()
+		_, _, err := CloudSource(nc, scs, "test")(context.Background(), updateCb)
+		require.Error(t, err)
+
+		sendUpdates(t, nc, sentUpdates)
+
+		requireNoReceive(t, updatesCh, time.Millisecond)
+		for _, getCronScriptResponse := range gotCronScriptResponses {
+			requireNoReceive(t, getCronScriptResponse, time.Millisecond)
+		}
+	})
+}
+
+func TestCloudScriptsSource_Updates(t *testing.T) {
+	tests := []struct {
+		name    string
+		scripts map[string]*cvmsgspb.CronScript
+		updates []*cvmsgspb.CronScriptUpdate
+	}{
+		{
+			name: "add one, delete one",
+			scripts: map[string]*cvmsgspb.CronScript{
+				"223e4567-e89b-12d3-a456-426655440001": {
+					ID:         utils.ProtoFromUUIDStrOrNil("223e4567-e89b-12d3-a456-426655440001"),
+					Script:     "test script 1",
+					Configs:    "config1",
+					FrequencyS: 123,
+				},
+			},
+			updates: []*cvmsgspb.CronScriptUpdate{
+				{
+					Msg: &cvmsgspb.CronScriptUpdate_UpsertReq{
+						UpsertReq: &cvmsgspb.RegisterOrUpdateCronScriptRequest{
+							Script: &cvmsgspb.CronScript{
+								ID:         utils.ProtoFromUUIDStrOrNil("223e4567-e89b-12d3-a456-426655440002"),
+								Script:     "test script 1",
+								Configs:    "config1",
+								FrequencyS: 123,
+							},
+						},
+					},
+					RequestID: "1",
+					Timestamp: 1,
+				},
+				{
+					Msg: &cvmsgspb.CronScriptUpdate_DeleteReq{
+						DeleteReq: &cvmsgspb.DeleteCronScriptRequest{
+							ScriptID: utils.ProtoFromUUIDStrOrNil("223e4567-e89b-12d3-a456-426655440001"),
+						},
+					},
+					RequestID: "2",
+					Timestamp: 2,
+				},
+			},
+		},
+		{
+			name: "update one, delete one",
+			scripts: map[string]*cvmsgspb.CronScript{
+				"223e4567-e89b-12d3-a456-426655440002": {
+					ID:         utils.ProtoFromUUIDStrOrNil("223e4567-e89b-12d3-a456-426655440002"),
+					Script:     "test script 1",
+					Configs:    "config1",
+					FrequencyS: 123,
+				},
+				"223e4567-e89b-12d3-a456-426655440001": {
+					ID:         utils.ProtoFromUUIDStrOrNil("223e4567-e89b-12d3-a456-426655440001"),
+					Script:     "test script 1",
+					Configs:    "config1",
+					FrequencyS: 123,
+				},
+			},
+			updates: []*cvmsgspb.CronScriptUpdate{
+				{
+					Msg: &cvmsgspb.CronScriptUpdate_UpsertReq{
+						UpsertReq: &cvmsgspb.RegisterOrUpdateCronScriptRequest{
+							Script: &cvmsgspb.CronScript{
+								ID:         utils.ProtoFromUUIDStrOrNil("223e4567-e89b-12d3-a456-426655440002"),
+								Script:     "test script 2",
+								Configs:    "config2",
+								FrequencyS: 123,
+							},
+						},
+					},
+					RequestID: "1",
+					Timestamp: 1,
+				},
+				{
+					Msg: &cvmsgspb.CronScriptUpdate_DeleteReq{
+						DeleteReq: &cvmsgspb.DeleteCronScriptRequest{
+							ScriptID: utils.ProtoFromUUIDStrOrNil("223e4567-e89b-12d3-a456-426655440001"),
+						},
+					},
+					RequestID: "2",
+					Timestamp: 2,
+				},
+			},
+		},
+		{
+			name:    "no scripts",
+			scripts: map[string]*cvmsgspb.CronScript{},
+			updates: []*cvmsgspb.CronScriptUpdate{
+				{
+					Msg: &cvmsgspb.CronScriptUpdate_UpsertReq{
+						UpsertReq: &cvmsgspb.RegisterOrUpdateCronScriptRequest{
+							Script: &cvmsgspb.CronScript{
+								ID:         utils.ProtoFromUUIDStrOrNil("223e4567-e89b-12d3-a456-426655440002"),
+								Script:     "test script 2",
+								Configs:    "config3",
+								FrequencyS: 123,
+							},
+						},
+					},
+					RequestID: "1",
+					Timestamp: 1,
+				},
+				{
+					Msg: &cvmsgspb.CronScriptUpdate_DeleteReq{
+						DeleteReq: &cvmsgspb.DeleteCronScriptRequest{
+							ScriptID: utils.ProtoFromUUIDStrOrNil("223e4567-e89b-12d3-a456-426655440003"),
+						},
+					},
+					RequestID: "2",
+					Timestamp: 2,
+				},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			nc, natsCleanup := testingutils.MustStartTestNATS(t)
+			defer natsCleanup()
+			persistedScripts := map[uuid.UUID]*cvmsgspb.CronScript{}
+			for id, script := range test.scripts {
+				persistedScripts[uuid.Must(uuid.FromString(id))] = script
+			}
+			fcs := &fakeCronStore{scripts: persistedScripts}
+
+			checksumSub, gotChecksumReq := setupChecksumSubscription(t, nc, test.scripts)
+			defer func() {
+				require.NoError(t, checksumSub.Unsubscribe())
+			}()
+
+			cronScriptResSubs, gotCronScriptResponses := setupCronScriptResponses(t, nc, test.updates)
+			defer func() {
+				for _, sub := range cronScriptResSubs {
+					require.NoError(t, sub.Unsubscribe())
+				}
+			}()
+
+			updateCb, updatesCh := mockUpdateCb()
+			_, stop, err := CloudSource(nc, fcs, "test")(context.Background(), updateCb)
+			require.NoError(t, err)
+			defer stop()
+
+			<-gotChecksumReq
+			sendUpdates(t, nc, test.updates)
+
+			missing := append([]*cvmsgspb.CronScriptUpdate{}, test.updates...)
+			var unexpected []*cvmsgspb.CronScriptUpdate
+			var actualUpdates []*cvmsgspb.CronScriptUpdate
+			for i := 0; i < len(test.updates); i++ {
+				select {
+				case actual := <-updatesCh:
+					actualUpdates = append(actualUpdates, actual)
+					anyMatches := false
+					for i, expected := range missing {
+						if reflect.DeepEqual(expected, actual) {
+							missing[i] = missing[len(missing)-1]
+							missing = missing[:len(missing)-1]
+							anyMatches = true
+							break
+						}
+					}
+					if !anyMatches {
+						unexpected = append(unexpected, actual)
+					}
+				case <-time.After(time.Millisecond):
+					break
+				}
+			}
+			require.Empty(t, missing, "missing updates")
+			require.Empty(t, unexpected, "unexpected updates")
+
+			for _, update := range actualUpdates {
+				requireReceiveWithin(t, gotCronScriptResponses[update.RequestID], time.Millisecond)
+				switch update.Msg.(type) {
+				case *cvmsgspb.CronScriptUpdate_UpsertReq:
+					req := update.GetUpsertReq()
+					require.Contains(t, fcs.scripts, utils.UUIDFromProtoOrNil(req.GetScript().GetID()))
+				case *cvmsgspb.CronScriptUpdate_DeleteReq:
+					req := update.GetDeleteReq()
+					require.NotContains(t, fcs.scripts, utils.UUIDFromProtoOrNil(req.GetScriptID()))
+				}
+			}
+		})
+	}
+
+	t.Run("does not send any further updates after stopping", func(t *testing.T) {
+		nc, natsCleanup := testingutils.MustStartTestNATS(t)
+		defer natsCleanup()
+		fcs := &fakeCronStore{scripts: nil}
+
+		checksumSub, _ := setupChecksumSubscription(t, nc, nil)
+		defer func() {
+			require.NoError(t, checksumSub.Unsubscribe())
+		}()
+
+		sentUpdates := []*cvmsgspb.CronScriptUpdate{
+			{
+				Msg: &cvmsgspb.CronScriptUpdate_UpsertReq{
+					UpsertReq: &cvmsgspb.RegisterOrUpdateCronScriptRequest{
+						Script: &cvmsgspb.CronScript{
+							ID:         utils.ProtoFromUUIDStrOrNil("223e4567-e89b-12d3-a456-426655440002"),
+							Script:     "test script 1",
+							Configs:    "config1",
+							FrequencyS: 123,
+						},
+					},
+				},
+				RequestID: "1",
+				Timestamp: 1,
+			},
+		}
+		cronScriptResSubs, gotCronScriptResponses := setupCronScriptResponses(t, nc, sentUpdates)
+		defer func() {
+			for _, sub := range cronScriptResSubs {
+				require.NoError(t, sub.Unsubscribe())
+			}
+		}()
+
+		updateCb, updatesCh := mockUpdateCb()
+		_, stop, err := CloudSource(nc, fcs, "test")(context.Background(), updateCb)
+		require.NoError(t, err)
+		stop()
+
+		sendUpdates(t, nc, sentUpdates)
+
+		requireNoReceive(t, updatesCh, time.Millisecond)
+		for _, getCronScriptResponse := range gotCronScriptResponses {
+			requireNoReceive(t, getCronScriptResponse, time.Millisecond)
+		}
+	})
+}
+
+func sendUpdates(t *testing.T, nc *nats.Conn, updates []*cvmsgspb.CronScriptUpdate) {
+	for _, update := range updates {
+		updateMsg, err := types.MarshalAny(update)
+		require.NoError(t, err)
+		c2vMsg := cvmsgspb.C2VMessage{Msg: updateMsg}
+		data, err := c2vMsg.Marshal()
+		require.NoError(t, err)
+		require.NoError(t, nc.Publish(CronScriptUpdatesChannel, data))
+	}
+}
+
+type stubCronScriptStore struct {
+	GetScriptsResponse *metadatapb.GetScriptsResponse
+	GetScriptsError    error
+
+	AddOrUpdateScriptResponse *metadatapb.AddOrUpdateScriptResponse
+	AddOrUpdateScriptError    error
+
+	DeleteScriptResponse *metadatapb.DeleteScriptResponse
+	DeleteScriptError    error
+
+	SetScriptsResponse *metadatapb.SetScriptsResponse
+	SetScriptsError    error
+
+	RecordExecutionResultResponse *metadatapb.RecordExecutionResultResponse
+	RecordExecutionResultError    error
+
+	GetAllExecutionResultsResponse *metadatapb.GetAllExecutionResultsResponse
+	GetAllExecutionResultsError    error
+}
+
+func (s *stubCronScriptStore) GetScripts(_ context.Context, _ *metadatapb.GetScriptsRequest, _ ...grpc.CallOption) (*metadatapb.GetScriptsResponse, error) {
+	return s.GetScriptsResponse, s.GetScriptsError
+}
+
+func (s *stubCronScriptStore) AddOrUpdateScript(_ context.Context, _ *metadatapb.AddOrUpdateScriptRequest, _ ...grpc.CallOption) (*metadatapb.AddOrUpdateScriptResponse, error) {
+	return s.AddOrUpdateScriptResponse, s.AddOrUpdateScriptError
+}
+
+func (s *stubCronScriptStore) DeleteScript(_ context.Context, _ *metadatapb.DeleteScriptRequest, _ ...grpc.CallOption) (*metadatapb.DeleteScriptResponse, error) {
+	return s.DeleteScriptResponse, s.DeleteScriptError
+}
+
+func (s *stubCronScriptStore) SetScripts(_ context.Context, _ *metadatapb.SetScriptsRequest, _ ...grpc.CallOption) (*metadatapb.SetScriptsResponse, error) {
+	return s.SetScriptsResponse, s.SetScriptsError
+}
+
+func (s *stubCronScriptStore) RecordExecutionResult(_ context.Context, _ *metadatapb.RecordExecutionResultRequest, _ ...grpc.CallOption) (*metadatapb.RecordExecutionResultResponse, error) {
+	return s.RecordExecutionResultResponse, s.RecordExecutionResultError
+}
+
+func (s *stubCronScriptStore) GetAllExecutionResults(_ context.Context, _ *metadatapb.GetAllExecutionResultsRequest, _ ...grpc.CallOption) (*metadatapb.GetAllExecutionResultsResponse, error) {
+	return s.GetAllExecutionResultsResponse, s.GetAllExecutionResultsError
+}
+
+func setupChecksumSubscription(t *testing.T, nc *nats.Conn, cloudScripts map[string]*cvmsgspb.CronScript) (*nats.Subscription, chan struct{}) {
+	gotChecksumReq := make(chan struct{}, 1)
+	checksumSub, err := nc.Subscribe(CronScriptChecksumRequestChannel, func(msg *nats.Msg) {
+		v2cMsg := &cvmsgspb.V2CMessage{}
+		err := proto.Unmarshal(msg.Data, v2cMsg)
+		require.NoError(t, err)
+		req := &cvmsgspb.GetCronScriptsChecksumRequest{}
+		err = types.UnmarshalAny(v2cMsg.Msg, req)
+		require.NoError(t, err)
+		topic := req.Topic
+
+		checksum, err := scripts.ChecksumFromScriptMap(cloudScripts)
+		require.NoError(t, err)
+
+		resp := &cvmsgspb.GetCronScriptsChecksumResponse{
+			Checksum: checksum,
+		}
+		respMsg, err := types.MarshalAny(resp)
+		require.NoError(t, err)
+		c2vMsg := cvmsgspb.C2VMessage{
+			Msg: respMsg,
+		}
+		data, err := c2vMsg.Marshal()
+		require.NoError(t, err)
+
+		err = nc.Publish(fmt.Sprintf("%s:%s", CronScriptChecksumResponseChannel, topic), data)
+		require.NoError(t, err)
+		gotChecksumReq <- struct{}{}
+	})
+	require.NoError(t, err)
+	return checksumSub, gotChecksumReq
+}
+
+func setupCronScriptResponses(t *testing.T, nc *nats.Conn, updates []*cvmsgspb.CronScriptUpdate) (map[string]*nats.Subscription, map[string]chan struct{}) {
+	subs := map[string]*nats.Subscription{}
+	gotResponses := map[string]chan struct{}{}
+	for _, update := range updates {
+		func(update *cvmsgspb.CronScriptUpdate) {
+			var err error
+			gotResponses[update.RequestID] = make(chan struct{}, 1)
+			subs[update.RequestID], err = nc.Subscribe(fmt.Sprintf("%s:%s", CronScriptUpdatesResponseChannel, update.RequestID), func(msg *nats.Msg) {
+				v2cMsg := &cvmsgspb.V2CMessage{}
+				err := proto.Unmarshal(msg.Data, v2cMsg)
+				require.NoError(t, err)
+				switch update.Msg.(type) {
+				case *cvmsgspb.CronScriptUpdate_UpsertReq:
+					res := &cvmsgspb.RegisterOrUpdateCronScriptResponse{}
+					err = types.UnmarshalAny(v2cMsg.Msg, res)
+					require.NoError(t, err)
+				case *cvmsgspb.CronScriptUpdate_DeleteReq:
+					res := &cvmsgspb.DeleteCronScriptResponse{}
+					err = types.UnmarshalAny(v2cMsg.Msg, res)
+					require.NoError(t, err)
+				default:
+					t.Fatalf("unexpected conn script response %s", reflect.TypeOf(update.Msg).Name())
+				}
+				gotResponses[update.RequestID] <- struct{}{}
+			})
+			require.NoError(t, err)
+		}(update)
+	}
+	return subs, gotResponses
+}
+
+func setupCloudScriptsSubscription(t *testing.T, nc *nats.Conn, cloudScripts map[string]*cvmsgspb.CronScript) (*nats.Subscription, chan struct{}) {
+	gotCronScripts := make(chan struct{}, 1)
+	scriptSub, err := nc.Subscribe(GetCronScriptsRequestChannel, func(msg *nats.Msg) {
+		v2cMsg := &cvmsgspb.V2CMessage{}
+		err := proto.Unmarshal(msg.Data, v2cMsg)
+		require.NoError(t, err)
+		req := &cvmsgspb.GetCronScriptsRequest{}
+		err = types.UnmarshalAny(v2cMsg.Msg, req)
+		require.NoError(t, err)
+
+		resp := &cvmsgspb.GetCronScriptsResponse{
+			Scripts: cloudScripts,
+		}
+		respMsg, err := types.MarshalAny(resp)
+		require.NoError(t, err)
+		c2vMsg := cvmsgspb.C2VMessage{
+			Msg: respMsg,
+		}
+		data, err := c2vMsg.Marshal()
+		require.NoError(t, err)
+
+		err = nc.Publish(fmt.Sprintf("%s:%s", GetCronScriptsResponseChannel, req.Topic), data)
+		require.NoError(t, err)
+		gotCronScripts <- struct{}{}
+	})
+	require.NoError(t, err)
+	return scriptSub, gotCronScripts
+}

--- a/src/vizier/services/query_broker/script_runner/config_map_source.go
+++ b/src/vizier/services/query_broker/script_runner/config_map_source.go
@@ -1,0 +1,129 @@
+/*
+ * Copyright 2018- The Pixie Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package scriptrunner
+
+import (
+	"context"
+	"time"
+
+	log "github.com/sirupsen/logrus"
+	"gopkg.in/yaml.v2"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/watch"
+	clientv1 "k8s.io/client-go/kubernetes/typed/core/v1"
+	"px.dev/pixie/src/shared/cvmsgspb"
+	"px.dev/pixie/src/utils"
+)
+
+// ConfigMapSource constructs a [Source] that extracts cron scripts from config maps with the label "purpose=cron-script".
+// Each config map must contain
+//   - a script.pxl with the pixel script
+//   - a configs.yaml which will be stored in the Configs field of [cvmsgspb.CronScript]
+//   - a cron.yaml that contains a "frequency_s" key
+func ConfigMapSource(client clientv1.ConfigMapInterface) Source {
+	return func(baseCtx context.Context, updateCb func(*cvmsgspb.CronScriptUpdate)) (map[string]*cvmsgspb.CronScript, func(), error) {
+		options := metav1.ListOptions{LabelSelector: "purpose=cron-script"}
+		watcher, err := client.Watch(baseCtx, options)
+		if err != nil {
+			return nil, nil, err
+		}
+		go configMapUpdater(watcher, updateCb)
+		configmaps, err := client.List(baseCtx, options)
+		if err != nil {
+			watcher.Stop()
+			return nil, nil, err
+		}
+		scripts := map[string]*cvmsgspb.CronScript{}
+		for _, configmap := range configmaps.Items {
+			id, cronScript, err := configmapToCronScript(&configmap)
+			if err != nil {
+				logCronScriptParseError(err)
+				continue
+			}
+			scripts[id] = cronScript
+		}
+		return scripts, watcher.Stop, nil
+	}
+}
+
+func configMapUpdater(watcher watch.Interface, updateCb func(*cvmsgspb.CronScriptUpdate)) {
+	for event := range watcher.ResultChan() {
+		switch event.Type {
+		case watch.Modified, watch.Added:
+			configmap := event.Object.(*v1.ConfigMap)
+			id, script, err := configmapToCronScript(configmap)
+			if err != nil {
+				logCronScriptParseError(err)
+				continue
+			}
+			cronScriptUpdate := &cvmsgspb.CronScriptUpdate{
+				Msg: &cvmsgspb.CronScriptUpdate_UpsertReq{
+					UpsertReq: &cvmsgspb.RegisterOrUpdateCronScriptRequest{
+						Script: script,
+					},
+				},
+				RequestID: id,
+				Timestamp: time.Now().Unix(),
+			}
+			updateCb(cronScriptUpdate)
+		case watch.Deleted:
+			configmap := event.Object.(*v1.ConfigMap)
+			id, script, err := configmapToCronScript(configmap)
+			if err != nil {
+				logCronScriptParseError(err)
+				continue
+			}
+			cronScriptUpdate := &cvmsgspb.CronScriptUpdate{
+				Msg: &cvmsgspb.CronScriptUpdate_DeleteReq{
+					DeleteReq: &cvmsgspb.DeleteCronScriptRequest{
+						ScriptID: script.ID,
+					},
+				},
+				RequestID: id,
+				Timestamp: time.Now().Unix(),
+			}
+			updateCb(cronScriptUpdate)
+		}
+	}
+}
+
+func logCronScriptParseError(err error) {
+	log.WithError(err).Error("Failed to parse cron.yaml from configmap cron script")
+}
+
+func configmapToCronScript(configmap *v1.ConfigMap) (string, *cvmsgspb.CronScript, error) {
+	id := string(configmap.UID)
+	cronScript := &cvmsgspb.CronScript{
+		ID:      utils.ProtoFromUUIDStrOrNil(id),
+		Script:  configmap.Data["script.pxl"],
+		Configs: configmap.Data["configs.yaml"],
+	}
+	var cronData cronYAML
+	err := yaml.Unmarshal([]byte(configmap.Data["cron.yaml"]), &cronData)
+	if err != nil {
+		return "", nil, err
+	}
+	cronScript.FrequencyS = cronData.FrequencyS
+	return id, cronScript, nil
+}
+
+type cronYAML struct {
+	FrequencyS int64 `yaml:"frequency_s"`
+}

--- a/src/vizier/services/query_broker/script_runner/config_map_source_test.go
+++ b/src/vizier/services/query_broker/script_runner/config_map_source_test.go
@@ -1,0 +1,207 @@
+/*
+ * Copyright 2018- The Pixie Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package scriptrunner
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/kubernetes/fake"
+	k8stesting "k8s.io/client-go/testing"
+	"px.dev/pixie/src/utils"
+)
+
+const ConfigMapUID = "5b054918-d670-45f3-99d4-015bb07036b3"
+
+func TestConfigMapScriptsSource(t *testing.T) {
+	t.Run("returns the initial scripts from a configmap", func(t *testing.T) {
+		client := fake.NewSimpleClientset(cronScriptConfigMap())
+		initialScripts, _, _ := ConfigMapSource(client.CoreV1().ConfigMaps("pl"))(context.Background(), dummyUpdateCb())
+
+		require.Len(t, initialScripts, 1)
+		initialScript := initialScripts[ConfigMapUID]
+		require.Equal(t, "px.display()", initialScript.Script)
+		require.Equal(t, "otelEndpointConfig: {url: example.com}", initialScript.Configs)
+		require.Equal(t, int64(1), initialScript.FrequencyS)
+	})
+
+	t.Run("reports an error when it cannot watch configmaps", func(t *testing.T) {
+		client := fake.NewSimpleClientset(cronScriptConfigMap())
+		client.PrependWatchReactor("configmaps", func(_ k8stesting.Action) (handled bool, ret watch.Interface, err error) {
+			return true, nil, errors.New("could not watch")
+		})
+		_, _, err := ConfigMapSource(client.CoreV1().ConfigMaps("pl"))(context.Background(), dummyUpdateCb())
+
+		require.Error(t, err)
+	})
+
+	t.Run("reports an error when it cannot list configmaps", func(t *testing.T) {
+		client := fake.NewSimpleClientset(cronScriptConfigMap())
+		client.PrependReactor("list", "configmaps", func(_ k8stesting.Action) (handled bool, ret runtime.Object, err error) {
+			return true, nil, errors.New("could not list")
+		})
+		syncConfigMaps := ConfigMapSource(client.CoreV1().ConfigMaps("pl"))
+
+		_, _, err := syncConfigMaps(context.Background(), dummyUpdateCb())
+
+		require.Error(t, err)
+	})
+
+	t.Run("reports an error when it cannot parse a configmap", func(t *testing.T) {
+		client := fake.NewSimpleClientset(cronScriptConfigMap())
+		client.PrependReactor("list", "configmaps", func(_ k8stesting.Action) (handled bool, ret runtime.Object, err error) {
+			return true, nil, errors.New("could not list")
+		})
+		syncConfigMaps := ConfigMapSource(client.CoreV1().ConfigMaps("pl"))
+
+		_, _, err := syncConfigMaps(context.Background(), dummyUpdateCb())
+
+		require.Error(t, err)
+	})
+
+	t.Run("does not watch configmaps when it cannot list them", func(t *testing.T) {
+		client := fake.NewSimpleClientset()
+		client.PrependReactor("list", "configmaps", func(_ k8stesting.Action) (handled bool, ret runtime.Object, err error) {
+			return true, nil, errors.New("could not list")
+		})
+		updateCb, updatesCh := mockUpdateCb()
+		syncConfigMaps := ConfigMapSource(client.CoreV1().ConfigMaps("pl"))
+
+		_, _, _ = syncConfigMaps(context.Background(), updateCb)
+
+		_, _ = client.CoreV1().ConfigMaps("pl").Create(context.Background(), cronScriptConfigMap(), metav1.CreateOptions{})
+
+		requireNoReceive(t, updatesCh, 10*time.Millisecond)
+	})
+
+	t.Run("stop causes no further updates to be sent", func(t *testing.T) {
+		client := fake.NewSimpleClientset()
+		updateCb, updatesCh := mockUpdateCb()
+		syncConfigMaps := ConfigMapSource(client.CoreV1().ConfigMaps("pl"))
+		_, stop, _ := syncConfigMaps(context.Background(), updateCb)
+
+		stop()
+
+		_, _ = client.CoreV1().ConfigMaps("pl").Create(context.Background(), cronScriptConfigMap(), metav1.CreateOptions{})
+
+		requireNoReceive(t, updatesCh, 10*time.Millisecond)
+	})
+
+	t.Run("only reports configmaps that have purpose=cron-script labels", func(t *testing.T) {
+		client := fake.NewSimpleClientset(&corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				UID:       "66b04d98-efbc-45e3-a805-b7c1d37e72fc",
+				Name:      "invalid-cron-script",
+				Namespace: "pl",
+				Labels:    map[string]string{},
+			},
+			Data: map[string]string{
+				"script.pxl":   "px.display()",
+				"configs.yaml": "otelEndpointConfig: {url: example.com}",
+				"cron.yaml":    "frequency_s: 1",
+			},
+		})
+		initialScripts, _, _ := ConfigMapSource(client.CoreV1().ConfigMaps("pl"))(context.Background(), dummyUpdateCb())
+
+		require.Empty(t, initialScripts)
+	})
+
+	t.Run("updates with newly added scripts", func(t *testing.T) {
+		client := fake.NewSimpleClientset()
+		updateCb, updatesCh := mockUpdateCb()
+		_, _, _ = ConfigMapSource(client.CoreV1().ConfigMaps("pl"))(context.Background(), updateCb)
+
+		_, _ = client.CoreV1().ConfigMaps("pl").Create(context.Background(), cronScriptConfigMap(), metav1.CreateOptions{})
+
+		update := requireReceiveWithin(t, updatesCh, time.Second)
+		cronscript := update.GetUpsertReq().GetScript()
+		require.Equal(t, utils.ProtoFromUUIDStrOrNil(ConfigMapUID), cronscript.GetID())
+		require.Equal(t, "px.display()", cronscript.GetScript())
+		require.Equal(t, "otelEndpointConfig: {url: example.com}", cronscript.GetConfigs())
+		require.Equal(t, int64(1), cronscript.GetFrequencyS())
+	})
+
+	t.Run("updates existing scripts", func(t *testing.T) {
+		configMapTemplate := cronScriptConfigMap()
+		client := fake.NewSimpleClientset(configMapTemplate)
+		updateCb, updatesCh := mockUpdateCb()
+		_, _, _ = ConfigMapSource(client.CoreV1().ConfigMaps("pl"))(context.Background(), updateCb)
+
+		configMapTemplate.Data["script.pxl"] = "px.display2()"
+		_, _ = client.CoreV1().ConfigMaps("pl").Update(context.Background(), configMapTemplate, metav1.UpdateOptions{})
+
+		update := requireReceiveWithin(t, updatesCh, time.Second)
+		cronscript := update.GetUpsertReq().GetScript()
+		require.Equal(t, utils.ProtoFromUUIDStrOrNil(ConfigMapUID), cronscript.GetID())
+		require.Equal(t, "px.display2()", cronscript.GetScript())
+		require.Equal(t, "otelEndpointConfig: {url: example.com}", cronscript.GetConfigs())
+		require.Equal(t, int64(1), cronscript.GetFrequencyS())
+	})
+
+	t.Run("excludes changes to configmaps that don't have purpose=cron-script labels", func(t *testing.T) {
+		watchLabelSelector := labels.NewSelector()
+		client := fake.NewSimpleClientset()
+		client.PrependWatchReactor("configmaps", func(action k8stesting.Action) (handled bool, ret watch.Interface, err error) {
+			watchLabelSelector = action.(k8stesting.WatchActionImpl).WatchRestrictions.Labels
+			return false, nil, nil
+		})
+		_, _, _ = ConfigMapSource(client.CoreV1().ConfigMaps("pl"))(context.Background(), dummyUpdateCb())
+
+		require.False(t, watchLabelSelector.Matches(labels.Set(map[string]string{})))
+		require.True(t, watchLabelSelector.Matches(labels.Set(map[string]string{"purpose": "cron-script"})))
+	})
+
+	t.Run("updates when a config map cron script is deleted", func(t *testing.T) {
+		configMapTemplate := cronScriptConfigMap()
+		client := fake.NewSimpleClientset(configMapTemplate)
+		updateCb, updatesCh := mockUpdateCb()
+		_, _, _ = ConfigMapSource(client.CoreV1().ConfigMaps("pl"))(context.Background(), updateCb)
+
+		configMapTemplate.Data["script.pxl"] = "px.display2()"
+		_ = client.CoreV1().ConfigMaps("pl").Delete(context.Background(), configMapTemplate.GetName(), metav1.DeleteOptions{})
+
+		update := requireReceiveWithin(t, updatesCh, time.Second)
+		deletedID := update.GetDeleteReq().ScriptID
+		require.Equal(t, ConfigMapUID, utils.ProtoToUUIDStr(deletedID))
+	})
+}
+
+func cronScriptConfigMap() *corev1.ConfigMap {
+	return &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			UID:       ConfigMapUID,
+			Name:      "cron-script-1",
+			Namespace: "pl",
+			Labels:    map[string]string{"purpose": "cron-script"},
+		},
+		Data: map[string]string{
+			"script.pxl":   "px.display()",
+			"configs.yaml": "otelEndpointConfig: {url: example.com}",
+			"cron.yaml":    "frequency_s: 1",
+		},
+	}
+}

--- a/src/vizier/services/query_broker/script_runner/helper_test.go
+++ b/src/vizier/services/query_broker/script_runner/helper_test.go
@@ -1,0 +1,183 @@
+package scriptrunner
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/gofrs/uuid"
+	"google.golang.org/grpc"
+	"px.dev/pixie/src/api/proto/vizierpb"
+	"px.dev/pixie/src/shared/cvmsgspb"
+	"px.dev/pixie/src/utils"
+	"px.dev/pixie/src/vizier/services/metadata/metadatapb"
+)
+
+func requireNoReceive[T any](t *testing.T, messages chan T, timeout time.Duration) {
+	t.Helper()
+	select {
+	case <-messages:
+		t.Fatal("should no longer receive any messages")
+	case <-time.After(timeout):
+		// it works
+	}
+}
+
+func requireReceiveWithin[T any](t *testing.T, messages chan T, timeout time.Duration) T {
+	t.Helper()
+	var message T
+	select {
+	case message = <-messages:
+	case <-time.After(timeout):
+		t.Fatalf("did not receive a message within %s", timeout.String())
+	}
+	return message
+}
+
+func fakeSource(scripts map[string]*cvmsgspb.CronScript, stop func(), err error) Source {
+	return func(_ context.Context, _ func(*cvmsgspb.CronScriptUpdate)) (map[string]*cvmsgspb.CronScript, func(), error) {
+		return scripts, stop, err
+	}
+}
+
+func dummySource() Source {
+	return func(_ context.Context, _ func(*cvmsgspb.CronScriptUpdate)) (map[string]*cvmsgspb.CronScript, func(), error) {
+		return nil, func() {}, nil
+	}
+}
+
+func errorSource(err error) Source {
+	return func(_ context.Context, _ func(*cvmsgspb.CronScriptUpdate)) (map[string]*cvmsgspb.CronScript, func(), error) {
+		return nil, nil, err
+	}
+}
+
+func dummyRunnerFactory(u uuid.UUID, script *cvmsgspb.CronScript) *runner {
+	return nil
+}
+
+type fakeCronStore struct {
+	scripts                 map[uuid.UUID]*cvmsgspb.CronScript
+	receivedResultRequestCh chan<- *metadatapb.RecordExecutionResultRequest
+}
+
+// GetScripts fetches all scripts in the cron script store.
+func (s *fakeCronStore) GetScripts(ctx context.Context, req *metadatapb.GetScriptsRequest, opts ...grpc.CallOption) (*metadatapb.GetScriptsResponse, error) {
+	if s.scripts == nil {
+		return &metadatapb.GetScriptsResponse{}, nil
+	}
+	m := make(map[string]*cvmsgspb.CronScript)
+	for k, v := range s.scripts {
+		m[k.String()] = v
+	}
+
+	return &metadatapb.GetScriptsResponse{
+		Scripts: m,
+	}, nil
+}
+
+// AddOrUpdateScript updates or adds a cron script to the store, based on ID.
+func (s *fakeCronStore) AddOrUpdateScript(ctx context.Context, req *metadatapb.AddOrUpdateScriptRequest, opts ...grpc.CallOption) (*metadatapb.AddOrUpdateScriptResponse, error) {
+	if s.scripts == nil {
+		s.scripts = map[uuid.UUID]*cvmsgspb.CronScript{}
+	}
+	s.scripts[utils.UUIDFromProtoOrNil(req.Script.ID)] = req.Script
+
+	return &metadatapb.AddOrUpdateScriptResponse{}, nil
+}
+
+// DeleteScript deletes a cron script from the store by ID.
+func (s *fakeCronStore) DeleteScript(ctx context.Context, req *metadatapb.DeleteScriptRequest, opts ...grpc.CallOption) (*metadatapb.DeleteScriptResponse, error) {
+	_, ok := s.scripts[utils.UUIDFromProtoOrNil(req.ScriptID)]
+	if ok {
+		delete(s.scripts, utils.UUIDFromProtoOrNil(req.ScriptID))
+	}
+
+	return &metadatapb.DeleteScriptResponse{}, nil
+}
+
+// SetScripts sets the list of all cron scripts to match the given set of scripts.
+func (s *fakeCronStore) SetScripts(ctx context.Context, req *metadatapb.SetScriptsRequest, opts ...grpc.CallOption) (*metadatapb.SetScriptsResponse, error) {
+	m := make(map[uuid.UUID]*cvmsgspb.CronScript)
+	for k, v := range req.Scripts {
+		m[uuid.FromStringOrNil(k)] = v
+	}
+	s.scripts = m
+
+	return &metadatapb.SetScriptsResponse{}, nil
+}
+
+// RecordExecutionResult stores the result of execution, whether that's an error or the stats about the execution.
+func (s *fakeCronStore) RecordExecutionResult(ctx context.Context, req *metadatapb.RecordExecutionResultRequest, opts ...grpc.CallOption) (*metadatapb.RecordExecutionResultResponse, error) {
+	s.receivedResultRequestCh <- req
+	return &metadatapb.RecordExecutionResultResponse{}, nil
+}
+
+// RecordExecutionResult stores the result of execution, whether that's an error or the stats about the execution.
+func (s *fakeCronStore) GetAllExecutionResults(ctx context.Context, req *metadatapb.GetAllExecutionResultsRequest, opts ...grpc.CallOption) (*metadatapb.GetAllExecutionResultsResponse, error) {
+	return &metadatapb.GetAllExecutionResultsResponse{}, nil
+}
+
+type fakeExecuteScriptClient struct {
+	// The error to send if not nil. The client does not send responses if this is not nil.
+	err       error
+	responses []*vizierpb.ExecuteScriptResponse
+	responseI int
+	grpc.ClientStream
+}
+
+func (es *fakeExecuteScriptClient) Recv() (*vizierpb.ExecuteScriptResponse, error) {
+	if es.err != nil {
+		return nil, es.err
+	}
+
+	resp := es.responses[es.responseI]
+	es.responseI++
+	return resp, nil
+}
+
+type fakeVizierServiceClient struct {
+	responses []*vizierpb.ExecuteScriptResponse
+	err       error
+}
+
+func (vs *fakeVizierServiceClient) ExecuteScript(ctx context.Context, in *vizierpb.ExecuteScriptRequest, opts ...grpc.CallOption) (vizierpb.VizierService_ExecuteScriptClient, error) {
+	return &fakeExecuteScriptClient{responses: vs.responses, err: vs.err}, nil
+}
+
+func (vs *fakeVizierServiceClient) HealthCheck(ctx context.Context, in *vizierpb.HealthCheckRequest, opts ...grpc.CallOption) (vizierpb.VizierService_HealthCheckClient, error) {
+	return nil, errors.New("Not implemented")
+}
+
+func (vs *fakeVizierServiceClient) GenerateOTelScript(ctx context.Context, req *vizierpb.GenerateOTelScriptRequest, opts ...grpc.CallOption) (*vizierpb.GenerateOTelScriptResponse, error) {
+	return nil, errors.New("Not implemented")
+}
+
+type FuncMatcher[T any] struct {
+	name    string
+	matches func(x T) bool
+}
+
+func NewCustomMatcher[T any](name string, matches func(x T) bool) *FuncMatcher[T] {
+	return &FuncMatcher[T]{name, matches}
+}
+
+func (f *FuncMatcher[T]) Matches(x interface{}) bool {
+	t, ok := x.(T)
+	return ok && f.matches(t)
+}
+
+func (f *FuncMatcher[T]) String() string {
+	return f.name
+}
+
+func dummyUpdateCb() func(*cvmsgspb.CronScriptUpdate) {
+	return func(*cvmsgspb.CronScriptUpdate) {}
+}
+
+func mockUpdateCb() (func(update *cvmsgspb.CronScriptUpdate), chan *cvmsgspb.CronScriptUpdate) {
+	updatesCh := make(chan *cvmsgspb.CronScriptUpdate)
+	updateCb := func(update *cvmsgspb.CronScriptUpdate) { updatesCh <- update }
+	return updateCb, updatesCh
+}

--- a/src/vizier/services/query_broker/script_runner/script_runner_test.go
+++ b/src/vizier/services/query_broker/script_runner/script_runner_test.go
@@ -21,636 +21,240 @@ package scriptrunner
 import (
 	"context"
 	"errors"
-	"fmt"
-	"sync"
+	"io"
 	"testing"
 	"time"
 
 	"github.com/gofrs/uuid"
-	"github.com/gogo/protobuf/proto"
 	"github.com/gogo/protobuf/types"
-	"github.com/nats-io/nats.go"
-	"github.com/stretchr/testify/assert"
+	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/require"
-	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
-
 	"px.dev/pixie/src/api/proto/vizierpb"
+	mock_vizierpb "px.dev/pixie/src/api/proto/vizierpb/mock"
 	"px.dev/pixie/src/carnot/planner/compilerpb"
 	"px.dev/pixie/src/common/base/statuspb"
 	"px.dev/pixie/src/shared/cvmsgspb"
-	"px.dev/pixie/src/shared/scripts"
 	"px.dev/pixie/src/utils"
-	"px.dev/pixie/src/utils/testingutils"
 	"px.dev/pixie/src/vizier/services/metadata/metadatapb"
 )
 
-func TestScriptRunner_CompareScriptState(t *testing.T) {
-	tests := []struct {
-		name             string
-		persistedScripts map[string]*cvmsgspb.CronScript
-		cloudScripts     map[string]*cvmsgspb.CronScript
-		checksumMatch    bool
-	}{
-		{
-			name: "checksums match",
-			persistedScripts: map[string]*cvmsgspb.CronScript{
-				"223e4567-e89b-12d3-a456-426655440000": {
-					ID:         utils.ProtoFromUUIDStrOrNil("223e4567-e89b-12d3-a456-426655440000"),
-					Script:     "px.display()",
-					Configs:    "config1",
-					FrequencyS: 5,
-				},
-				"223e4567-e89b-12d3-a456-426655440001": {
-					ID:         utils.ProtoFromUUIDStrOrNil("223e4567-e89b-12d3-a456-426655440001"),
-					Script:     "test script",
-					Configs:    "config2",
-					FrequencyS: 22,
-				},
-			},
-			cloudScripts: map[string]*cvmsgspb.CronScript{
-				"223e4567-e89b-12d3-a456-426655440000": {
-					ID:         utils.ProtoFromUUIDStrOrNil("223e4567-e89b-12d3-a456-426655440000"),
-					Script:     "px.display()",
-					Configs:    "config1",
-					FrequencyS: 5,
-				},
-				"223e4567-e89b-12d3-a456-426655440001": {
-					ID:         utils.ProtoFromUUIDStrOrNil("223e4567-e89b-12d3-a456-426655440001"),
-					Script:     "test script",
-					Configs:    "config2",
-					FrequencyS: 22,
-				},
-			},
-			checksumMatch: true,
-		},
-		{
-			name: "checksums mismatch: one field different",
-			persistedScripts: map[string]*cvmsgspb.CronScript{
-				"223e4567-e89b-12d3-a456-426655440000": {
-					ID:         utils.ProtoFromUUIDStrOrNil("223e4567-e89b-12d3-a456-426655440000"),
-					Script:     "px.display()",
-					Configs:    "config1",
-					FrequencyS: 5,
-				},
-				"223e4567-e89b-12d3-a456-426655440001": {
-					ID:         utils.ProtoFromUUIDStrOrNil("223e4567-e89b-12d3-a456-426655440001"),
-					Script:     "test script",
-					Configs:    "config2",
-					FrequencyS: 22,
-				},
-			},
-			cloudScripts: map[string]*cvmsgspb.CronScript{
-				"223e4567-e89b-12d3-a456-426655440000": {
-					ID:         utils.ProtoFromUUIDStrOrNil("223e4567-e89b-12d3-a456-426655440000"),
-					Script:     "px.display()",
-					Configs:    "config1",
-					FrequencyS: 6,
-				},
-				"223e4567-e89b-12d3-a456-426655440001": {
-					ID:         utils.ProtoFromUUIDStrOrNil("223e4567-e89b-12d3-a456-426655440001"),
-					Script:     "test script",
-					Configs:    "config2",
-					FrequencyS: 22,
-				},
-			},
-			checksumMatch: false,
-		},
-		{
-			name: "checksums mismatch: missing script",
-			persistedScripts: map[string]*cvmsgspb.CronScript{
-				"223e4567-e89b-12d3-a456-426655440000": {
-					ID:         utils.ProtoFromUUIDStrOrNil("223e4567-e89b-12d3-a456-426655440000"),
-					Script:     "px.display()",
-					Configs:    "config1",
-					FrequencyS: 5,
-				},
-				"223e4567-e89b-12d3-a456-426655440001": {
-					ID:         utils.ProtoFromUUIDStrOrNil("223e4567-e89b-12d3-a456-426655440001"),
-					Script:     "test script",
-					Configs:    "config2",
-					FrequencyS: 22,
-				},
-			},
-			cloudScripts: map[string]*cvmsgspb.CronScript{
-				"223e4567-e89b-12d3-a456-426655440000": {
-					ID:         utils.ProtoFromUUIDStrOrNil("223e4567-e89b-12d3-a456-426655440000"),
-					Script:     "px.display()",
-					Configs:    "config1",
-					FrequencyS: 6,
-				},
-			},
-			checksumMatch: false,
-		},
-		{
-			name:             "checksums match: empty",
-			persistedScripts: map[string]*cvmsgspb.CronScript{},
-			cloudScripts:     map[string]*cvmsgspb.CronScript{},
-			checksumMatch:    true,
-		},
-	}
-
-	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
-			nc, natsCleanup := testingutils.MustStartTestNATS(t)
-			defer natsCleanup()
-			fvs := &fakeVizierServiceClient{err: errors.New("not implemented")}
-			sr, err := New(nc, &fakeCronStore{scripts: map[uuid.UUID]*cvmsgspb.CronScript{}}, fvs, "test")
-			require.NoError(t, err)
-
-			// Subscribe to request channel.
-			mdSub, err := nc.Subscribe(CronScriptChecksumRequestChannel, func(msg *nats.Msg) {
-				v2cMsg := &cvmsgspb.V2CMessage{}
-				err := proto.Unmarshal(msg.Data, v2cMsg)
-				require.NoError(t, err)
-				req := &cvmsgspb.GetCronScriptsChecksumRequest{}
-				err = types.UnmarshalAny(v2cMsg.Msg, req)
-				require.NoError(t, err)
-				topic := req.Topic
-
-				checksum, err := scripts.ChecksumFromScriptMap(test.cloudScripts)
-				require.NoError(t, err)
-				resp := &cvmsgspb.GetCronScriptsChecksumResponse{
-					Checksum: checksum,
-				}
-				anyMsg, err := types.MarshalAny(resp)
-				require.NoError(t, err)
-				c2vMsg := cvmsgspb.C2VMessage{
-					Msg: anyMsg,
-				}
-				b, err := c2vMsg.Marshal()
-				require.NoError(t, err)
-
-				err = nc.Publish(fmt.Sprintf("%s:%s", CronScriptChecksumResponseChannel, topic), b)
-				require.NoError(t, err)
-			})
-			defer func() {
-				err = mdSub.Unsubscribe()
-				require.NoError(t, err)
-			}()
-			match, err := sr.compareScriptState(test.persistedScripts)
-			require.Nil(t, err)
-			assert.Equal(t, test.checksumMatch, match)
-		})
-	}
-}
-
-func TestScriptRunner_GetCloudScripts(t *testing.T) {
-	nc, natsCleanup := testingutils.MustStartTestNATS(t)
-	defer natsCleanup()
-
-	fvs := &fakeVizierServiceClient{err: errors.New("not implemented")}
-	sr, err := New(nc, nil, fvs, "test")
-	require.NoError(t, err)
-
-	scripts := map[string]*cvmsgspb.CronScript{
-		"223e4567-e89b-12d3-a456-426655440000": {
-			ID:         utils.ProtoFromUUIDStrOrNil("223e4567-e89b-12d3-a456-426655440000"),
-			Script:     "px.display()",
-			Configs:    "config1",
-			FrequencyS: 5,
-		},
-		"223e4567-e89b-12d3-a456-426655440001": {
-			ID:         utils.ProtoFromUUIDStrOrNil("223e4567-e89b-12d3-a456-426655440001"),
-			Script:     "test script",
-			Configs:    "config2",
-			FrequencyS: 22,
-		},
-	}
-
-	// Subscribe to request channel.
-	mdSub, err := nc.Subscribe(GetCronScriptsRequestChannel, func(msg *nats.Msg) {
-		v2cMsg := &cvmsgspb.V2CMessage{}
-		err := proto.Unmarshal(msg.Data, v2cMsg)
-		require.NoError(t, err)
-		req := &cvmsgspb.GetCronScriptsRequest{}
-		err = types.UnmarshalAny(v2cMsg.Msg, req)
-		require.NoError(t, err)
-		topic := req.Topic
-
-		resp := &cvmsgspb.GetCronScriptsResponse{
-			Scripts: scripts,
-		}
-		anyMsg, err := types.MarshalAny(resp)
-		require.NoError(t, err)
-		c2vMsg := cvmsgspb.C2VMessage{
-			Msg: anyMsg,
-		}
-		b, err := c2vMsg.Marshal()
-		require.NoError(t, err)
-
-		err = nc.Publish(fmt.Sprintf("%s:%s", GetCronScriptsResponseChannel, topic), b)
-		require.NoError(t, err)
-	})
-	defer func() {
-		err = mdSub.Unsubscribe()
-		require.NoError(t, err)
-	}()
-
-	resp, err := sr.getCloudScripts()
-	require.Nil(t, err)
-	assert.Equal(t, scripts, resp)
-}
-
-type fakeCronStore struct {
-	scripts                 map[uuid.UUID]*cvmsgspb.CronScript
-	receivedResultRequestCh chan<- *metadatapb.RecordExecutionResultRequest
-}
-
-// GetScripts fetches all scripts in the cron script store.
-func (s *fakeCronStore) GetScripts(ctx context.Context, req *metadatapb.GetScriptsRequest, opts ...grpc.CallOption) (*metadatapb.GetScriptsResponse, error) {
-	m := make(map[string]*cvmsgspb.CronScript)
-	for k, v := range s.scripts {
-		m[k.String()] = v
-	}
-
-	return &metadatapb.GetScriptsResponse{
-		Scripts: m,
-	}, nil
-}
-
-// AddOrUpdateScript updates or adds a cron script to the store, based on ID.
-func (s *fakeCronStore) AddOrUpdateScript(ctx context.Context, req *metadatapb.AddOrUpdateScriptRequest, opts ...grpc.CallOption) (*metadatapb.AddOrUpdateScriptResponse, error) {
-	s.scripts[utils.UUIDFromProtoOrNil(req.Script.ID)] = req.Script
-
-	return &metadatapb.AddOrUpdateScriptResponse{}, nil
-}
-
-// DeleteScript deletes a cron script from the store by ID.
-func (s *fakeCronStore) DeleteScript(ctx context.Context, req *metadatapb.DeleteScriptRequest, opts ...grpc.CallOption) (*metadatapb.DeleteScriptResponse, error) {
-	_, ok := s.scripts[utils.UUIDFromProtoOrNil(req.ScriptID)]
-	if ok {
-		delete(s.scripts, utils.UUIDFromProtoOrNil(req.ScriptID))
-	}
-
-	return &metadatapb.DeleteScriptResponse{}, nil
-}
-
-// SetScripts sets the list of all cron scripts to match the given set of scripts.
-func (s *fakeCronStore) SetScripts(ctx context.Context, req *metadatapb.SetScriptsRequest, opts ...grpc.CallOption) (*metadatapb.SetScriptsResponse, error) {
-	m := make(map[uuid.UUID]*cvmsgspb.CronScript)
-	for k, v := range req.Scripts {
-		m[uuid.FromStringOrNil(k)] = v
-	}
-	s.scripts = m
-
-	return &metadatapb.SetScriptsResponse{}, nil
-}
-
-// RecordExecutionResult stores the result of execution, whether that's an error or the stats about the execution.
-func (s *fakeCronStore) RecordExecutionResult(ctx context.Context, req *metadatapb.RecordExecutionResultRequest, opts ...grpc.CallOption) (*metadatapb.RecordExecutionResultResponse, error) {
-	s.receivedResultRequestCh <- req
-	return &metadatapb.RecordExecutionResultResponse{}, nil
-}
-
-// RecordExecutionResult stores the result of execution, whether that's an error or the stats about the execution.
-func (s *fakeCronStore) GetAllExecutionResults(ctx context.Context, req *metadatapb.GetAllExecutionResultsRequest, opts ...grpc.CallOption) (*metadatapb.GetAllExecutionResultsResponse, error) {
-	return &metadatapb.GetAllExecutionResultsResponse{}, nil
-}
-
 func TestScriptRunner_SyncScripts(t *testing.T) {
+	t.Run("returns an error when the script source fails", func(t *testing.T) {
+		err := errors.New("failed to initialize scripts")
+		sr := New(nil, nil, "test", errorSource(err))
+
+		require.Error(t, sr.SyncScripts())
+	})
+
+	t.Run("returns when we call Stop", func(t *testing.T) {
+		sr := New(nil, nil, "test", dummySource())
+		stopped := make(chan struct{}, 1)
+
+		go func() {
+			require.NoError(t, sr.SyncScripts())
+			stopped <- struct{}{}
+		}()
+
+		requireNoReceive(t, stopped, time.Millisecond)
+
+		sr.Stop()
+
+		requireReceiveWithin(t, stopped, 10*time.Millisecond)
+	})
+
+	t.Run("stops updates when we stop the ScriptRunner", func(t *testing.T) {
+		stopped := make(chan struct{}, 1)
+		sr := New(nil, nil, "test", fakeSource(nil, func() {
+			stopped <- struct{}{}
+		}, nil))
+
+		go func() {
+			require.NoError(t, sr.SyncScripts())
+		}()
+
+		requireNoReceive(t, stopped, time.Millisecond)
+
+		sr.Stop()
+
+		requireReceiveWithin(t, stopped, 10*time.Millisecond)
+	})
+
+	t.Run("runs initial scripts on an interval", func(t *testing.T) {
+		const scriptID = "223e4567-e89b-12d3-a456-426655440002"
+		ctrl := gomock.NewController(t)
+		mvs := mock_vizierpb.NewMockVizierServiceClient(ctrl)
+		mvsExecuteScriptClient := mock_vizierpb.NewMockVizierService_ExecuteScriptClient(ctrl)
+		mvsExecuteScriptClient.EXPECT().
+			Recv().
+			Return(nil, io.EOF).
+			Times(1)
+
+		scriptExecuted := make(chan struct{}, 1)
+		mvs.EXPECT().
+			ExecuteScript(
+				gomock.Not(gomock.Nil()),
+				NewCustomMatcher(
+					"an ExecuteScriptRequest with the proper QueryName",
+					func(req *vizierpb.ExecuteScriptRequest) bool {
+						return req.GetQueryName() == "cron_"+scriptID
+					},
+				),
+			).
+			Do(func(_ context.Context, _ *vizierpb.ExecuteScriptRequest) { scriptExecuted <- struct{}{} }).
+			Return(mvsExecuteScriptClient, nil).
+			Times(1)
+
+		fcs := &fakeCronStore{scripts: map[uuid.UUID]*cvmsgspb.CronScript{}}
+		source := fakeSource(map[string]*cvmsgspb.CronScript{
+			scriptID: {
+				ID:         utils.ProtoFromUUIDStrOrNil(scriptID),
+				Script:     "px.display()",
+				Configs:    "otelEndpointConfig: {url: example.com}",
+				FrequencyS: 1,
+			},
+		}, func() {}, nil)
+		sr := New(fcs, mvs, "test", source)
+
+		go func() {
+			require.NoError(t, sr.SyncScripts())
+		}()
+		defer sr.Stop()
+
+		requireReceiveWithin(t, scriptExecuted, 10*time.Second)
+	})
+
+	t.Run("stops executing scripts when we stop the ScriptRunner", func(t *testing.T) {
+		const scriptID = "223e4567-e89b-12d3-a456-426655440002"
+		ctrl := gomock.NewController(t)
+		scriptExecuted := make(chan struct{}, 1)
+		mvsExecuteScriptClient := mock_vizierpb.NewMockVizierService_ExecuteScriptClient(ctrl)
+		mvsExecuteScriptClient.EXPECT().
+			Recv().
+			Return(nil, io.EOF).
+			Times(1)
+
+		mvs := mock_vizierpb.NewMockVizierServiceClient(ctrl)
+		mvs.EXPECT().
+			ExecuteScript(
+				gomock.Any(),
+				gomock.Any(),
+			).
+			Do(func(_ context.Context, _ *vizierpb.ExecuteScriptRequest) { scriptExecuted <- struct{}{} }).
+			Return(mvsExecuteScriptClient, nil).
+			Times(1)
+
+		fcs := &fakeCronStore{scripts: map[uuid.UUID]*cvmsgspb.CronScript{}}
+		source := fakeSource(map[string]*cvmsgspb.CronScript{
+			scriptID: {
+				ID:         utils.ProtoFromUUIDStrOrNil(scriptID),
+				Script:     "px.display()",
+				Configs:    "otelEndpointConfig: {url: example.com}",
+				FrequencyS: 1,
+			},
+		}, func() {}, nil)
+		sr := New(fcs, mvs, "test", source)
+
+		go func() {
+			require.NoError(t, sr.SyncScripts())
+		}()
+
+		requireReceiveWithin(t, scriptExecuted, 10*time.Second)
+
+		sr.Stop()
+
+		requireNoReceive(t, scriptExecuted, 1100*time.Millisecond)
+	})
+}
+
+func TestScriptRunner_ScriptUpdates(t *testing.T) {
+	const scriptID = "223e4567-e89b-12d3-a456-426655440002"
 	tests := []struct {
-		name             string
-		persistedScripts map[string]*cvmsgspb.CronScript
-		cloudScripts     map[string]*cvmsgspb.CronScript
-		updates          []*cvmsgspb.CronScriptUpdate
-		expectedScripts  map[string]*cvmsgspb.CronScript
+		name     string
+		queryStr string
+		updates  []*cvmsgspb.CronScriptUpdate
 	}{
 		{
-			name: "initial match",
-			persistedScripts: map[string]*cvmsgspb.CronScript{
-				"223e4567-e89b-12d3-a456-426655440000": {
-					ID:         utils.ProtoFromUUIDStrOrNil("223e4567-e89b-12d3-a456-426655440000"),
-					Script:     "px.display()",
-					Configs:    "config1",
-					FrequencyS: 5,
-				},
-				"223e4567-e89b-12d3-a456-426655440001": {
-					ID:         utils.ProtoFromUUIDStrOrNil("223e4567-e89b-12d3-a456-426655440001"),
-					Script:     "test script",
-					Configs:    "config2",
-					FrequencyS: 22,
-				},
-			},
-			cloudScripts: map[string]*cvmsgspb.CronScript{
-				"223e4567-e89b-12d3-a456-426655440000": {
-					ID:         utils.ProtoFromUUIDStrOrNil("223e4567-e89b-12d3-a456-426655440000"),
-					Script:     "px.display()",
-					Configs:    "config1",
-					FrequencyS: 5,
-				},
-				"223e4567-e89b-12d3-a456-426655440001": {
-					ID:         utils.ProtoFromUUIDStrOrNil("223e4567-e89b-12d3-a456-426655440001"),
-					Script:     "test script",
-					Configs:    "config2",
-					FrequencyS: 22,
-				},
-			},
+			name:     "tracks new cron scripts",
+			queryStr: "updated script",
 			updates: []*cvmsgspb.CronScriptUpdate{
 				{
 					Msg: &cvmsgspb.CronScriptUpdate_UpsertReq{
 						UpsertReq: &cvmsgspb.RegisterOrUpdateCronScriptRequest{
 							Script: &cvmsgspb.CronScript{
-								ID:         utils.ProtoFromUUIDStrOrNil("223e4567-e89b-12d3-a456-426655440002"),
-								Script:     "test script 2",
-								Configs:    "config3",
-								FrequencyS: 123,
+								ID:         utils.ProtoFromUUIDStrOrNil(scriptID),
+								Script:     "updated script",
+								Configs:    "otelEndpointConfig: {url: example.com}",
+								FrequencyS: 1,
 							},
 						},
 					},
-					RequestID: "1",
 					Timestamp: 1,
-				},
-				{
-					Msg: &cvmsgspb.CronScriptUpdate_DeleteReq{
-						DeleteReq: &cvmsgspb.DeleteCronScriptRequest{
-							ScriptID: utils.ProtoFromUUIDStrOrNil("223e4567-e89b-12d3-a456-426655440001"),
-						},
-					},
-					RequestID: "2",
-					Timestamp: 2,
-				},
-			},
-			expectedScripts: map[string]*cvmsgspb.CronScript{
-				"223e4567-e89b-12d3-a456-426655440000": {
-					ID:         utils.ProtoFromUUIDStrOrNil("223e4567-e89b-12d3-a456-426655440000"),
-					Script:     "px.display()",
-					Configs:    "config1",
-					FrequencyS: 5,
-				},
-				"223e4567-e89b-12d3-a456-426655440002": {
-					ID:         utils.ProtoFromUUIDStrOrNil("223e4567-e89b-12d3-a456-426655440002"),
-					Script:     "test script 2",
-					Configs:    "config3",
-					FrequencyS: 123,
 				},
 			},
 		},
 		{
-			name: "initial mismatch",
-			persistedScripts: map[string]*cvmsgspb.CronScript{
-				"223e4567-e89b-12d3-a456-426655440000": {
-					ID:         utils.ProtoFromUUIDStrOrNil("223e4567-e89b-12d3-a456-426655440000"),
-					Script:     "px.display()",
-					Configs:    "config1",
-					FrequencyS: 5,
-				},
-				"223e4567-e89b-12d3-a456-426655440001": {
-					ID:         utils.ProtoFromUUIDStrOrNil("223e4567-e89b-12d3-a456-426655440001"),
-					Script:     "test script",
-					Configs:    "config2",
-					FrequencyS: 22,
-				},
-			},
-			cloudScripts: map[string]*cvmsgspb.CronScript{
-				"223e4567-e89b-12d3-a456-426655440001": {
-					ID:         utils.ProtoFromUUIDStrOrNil("223e4567-e89b-12d3-a456-426655440001"),
-					Script:     "test script",
-					Configs:    "config2",
-					FrequencyS: 22,
-				},
-			},
+			name:     "tracks updates to cron scripts",
+			queryStr: "second updated script",
 			updates: []*cvmsgspb.CronScriptUpdate{
 				{
 					Msg: &cvmsgspb.CronScriptUpdate_UpsertReq{
 						UpsertReq: &cvmsgspb.RegisterOrUpdateCronScriptRequest{
 							Script: &cvmsgspb.CronScript{
-								ID:         utils.ProtoFromUUIDStrOrNil("223e4567-e89b-12d3-a456-426655440002"),
-								Script:     "test script 2",
-								Configs:    "config3",
-								FrequencyS: 123,
+								ID:         utils.ProtoFromUUIDStrOrNil(scriptID),
+								Script:     "updated script",
+								Configs:    "otelEndpointConfig: {url: example.com}",
+								FrequencyS: 1,
 							},
 						},
 					},
-					RequestID: "1",
 					Timestamp: 1,
 				},
 				{
-					Msg: &cvmsgspb.CronScriptUpdate_DeleteReq{
-						DeleteReq: &cvmsgspb.DeleteCronScriptRequest{
-							ScriptID: utils.ProtoFromUUIDStrOrNil("223e4567-e89b-12d3-a456-426655440001"),
+					Msg: &cvmsgspb.CronScriptUpdate_UpsertReq{
+						UpsertReq: &cvmsgspb.RegisterOrUpdateCronScriptRequest{
+							Script: &cvmsgspb.CronScript{
+								ID:         utils.ProtoFromUUIDStrOrNil(scriptID),
+								Script:     "second updated script",
+								Configs:    "otelEndpointConfig: {url: example.com}",
+								FrequencyS: 1,
+							},
 						},
 					},
-					RequestID: "2",
 					Timestamp: 2,
-				},
-			},
-			expectedScripts: map[string]*cvmsgspb.CronScript{
-				"223e4567-e89b-12d3-a456-426655440002": {
-					ID:         utils.ProtoFromUUIDStrOrNil("223e4567-e89b-12d3-a456-426655440002"),
-					Script:     "test script 2",
-					Configs:    "config3",
-					FrequencyS: 123,
 				},
 			},
 		},
 		{
-			name:             "persisted empty",
-			persistedScripts: map[string]*cvmsgspb.CronScript{},
-			cloudScripts: map[string]*cvmsgspb.CronScript{
-				"223e4567-e89b-12d3-a456-426655440001": {
-					ID:         utils.ProtoFromUUIDStrOrNil("223e4567-e89b-12d3-a456-426655440001"),
-					Script:     "test script",
-					Configs:    "config2",
-					FrequencyS: 22,
-				},
-			},
+			name:     "discards out of order updates",
+			queryStr: "second updated script",
 			updates: []*cvmsgspb.CronScriptUpdate{
 				{
 					Msg: &cvmsgspb.CronScriptUpdate_UpsertReq{
 						UpsertReq: &cvmsgspb.RegisterOrUpdateCronScriptRequest{
 							Script: &cvmsgspb.CronScript{
-								ID:         utils.ProtoFromUUIDStrOrNil("223e4567-e89b-12d3-a456-426655440002"),
-								Script:     "test script 2",
-								Configs:    "config3",
-								FrequencyS: 123,
+								ID:         utils.ProtoFromUUIDStrOrNil(scriptID),
+								Script:     "second updated script",
+								Configs:    "otelEndpointConfig: {url: example.com}",
+								FrequencyS: 1,
 							},
 						},
 					},
-					RequestID: "1",
+					Timestamp: 2,
+				},
+				{
+					Msg: &cvmsgspb.CronScriptUpdate_UpsertReq{
+						UpsertReq: &cvmsgspb.RegisterOrUpdateCronScriptRequest{
+							Script: &cvmsgspb.CronScript{
+								ID:         utils.ProtoFromUUIDStrOrNil(scriptID),
+								Script:     "first updated script",
+								Configs:    "otelEndpointConfig: {url: example.com}",
+								FrequencyS: 1,
+							},
+						},
+					},
 					Timestamp: 1,
-				},
-				{
-					Msg: &cvmsgspb.CronScriptUpdate_DeleteReq{
-						DeleteReq: &cvmsgspb.DeleteCronScriptRequest{
-							ScriptID: utils.ProtoFromUUIDStrOrNil("223e4567-e89b-12d3-a456-426655440003"),
-						},
-					},
-					RequestID: "2",
-					Timestamp: 2,
-				},
-			},
-			expectedScripts: map[string]*cvmsgspb.CronScript{
-				"223e4567-e89b-12d3-a456-426655440001": {
-					ID:         utils.ProtoFromUUIDStrOrNil("223e4567-e89b-12d3-a456-426655440001"),
-					Script:     "test script",
-					Configs:    "config2",
-					FrequencyS: 22,
-				},
-				"223e4567-e89b-12d3-a456-426655440002": {
-					ID:         utils.ProtoFromUUIDStrOrNil("223e4567-e89b-12d3-a456-426655440002"),
-					Script:     "test script 2",
-					Configs:    "config3",
-					FrequencyS: 123,
-				},
-			},
-		},
-		{
-			name:             "cloud empty",
-			persistedScripts: map[string]*cvmsgspb.CronScript{},
-			cloudScripts:     map[string]*cvmsgspb.CronScript{},
-			updates: []*cvmsgspb.CronScriptUpdate{
-				{
-					Msg: &cvmsgspb.CronScriptUpdate_UpsertReq{
-						UpsertReq: &cvmsgspb.RegisterOrUpdateCronScriptRequest{
-							Script: &cvmsgspb.CronScript{
-								ID:         utils.ProtoFromUUIDStrOrNil("223e4567-e89b-12d3-a456-426655440002"),
-								Script:     "test script 2",
-								Configs:    "config3",
-								FrequencyS: 123,
-							},
-						},
-					},
-					RequestID: "1",
-					Timestamp: 1,
-				},
-				{
-					Msg: &cvmsgspb.CronScriptUpdate_UpsertReq{
-						UpsertReq: &cvmsgspb.RegisterOrUpdateCronScriptRequest{
-							Script: &cvmsgspb.CronScript{
-								ID:         utils.ProtoFromUUIDStrOrNil("223e4567-e89b-12d3-a456-426655440003"),
-								Script:     "test script 2",
-								Configs:    "config3",
-								FrequencyS: 123,
-							},
-						},
-					},
-					RequestID: "2",
-					Timestamp: 2,
-				},
-				{
-					Msg: &cvmsgspb.CronScriptUpdate_UpsertReq{
-						UpsertReq: &cvmsgspb.RegisterOrUpdateCronScriptRequest{
-							Script: &cvmsgspb.CronScript{
-								ID:         utils.ProtoFromUUIDStrOrNil("223e4567-e89b-12d3-a456-426655440004"),
-								Script:     "test script 2",
-								Configs:    "config3",
-								FrequencyS: 123,
-							},
-						},
-					},
-					RequestID: "3",
-					Timestamp: 3,
-				},
-				{
-					Msg: &cvmsgspb.CronScriptUpdate_DeleteReq{
-						DeleteReq: &cvmsgspb.DeleteCronScriptRequest{
-							ScriptID: utils.ProtoFromUUIDStrOrNil("223e4567-e89b-12d3-a456-426655440003"),
-						},
-					},
-					RequestID: "4",
-					Timestamp: 4,
-				},
-			},
-			expectedScripts: map[string]*cvmsgspb.CronScript{
-				"223e4567-e89b-12d3-a456-426655440002": {
-					ID:         utils.ProtoFromUUIDStrOrNil("223e4567-e89b-12d3-a456-426655440002"),
-					Script:     "test script 2",
-					Configs:    "config3",
-					FrequencyS: 123,
-				},
-				"223e4567-e89b-12d3-a456-426655440004": {
-					ID:         utils.ProtoFromUUIDStrOrNil("223e4567-e89b-12d3-a456-426655440004"),
-					Script:     "test script 2",
-					Configs:    "config3",
-					FrequencyS: 123,
-				},
-			},
-		},
-		{
-			name:             "out-of-order update",
-			persistedScripts: map[string]*cvmsgspb.CronScript{},
-			cloudScripts:     map[string]*cvmsgspb.CronScript{},
-			updates: []*cvmsgspb.CronScriptUpdate{
-				{
-					Msg: &cvmsgspb.CronScriptUpdate_UpsertReq{
-						UpsertReq: &cvmsgspb.RegisterOrUpdateCronScriptRequest{
-							Script: &cvmsgspb.CronScript{
-								ID:         utils.ProtoFromUUIDStrOrNil("223e4567-e89b-12d3-a456-426655440002"),
-								Script:     "test script 2",
-								Configs:    "config3",
-								FrequencyS: 123,
-							},
-						},
-					},
-					RequestID: "1",
-					Timestamp: 1,
-				},
-				{
-					Msg: &cvmsgspb.CronScriptUpdate_UpsertReq{
-						UpsertReq: &cvmsgspb.RegisterOrUpdateCronScriptRequest{
-							Script: &cvmsgspb.CronScript{
-								ID:         utils.ProtoFromUUIDStrOrNil("223e4567-e89b-12d3-a456-426655440003"),
-								Script:     "test script 2",
-								Configs:    "config3",
-								FrequencyS: 123,
-							},
-						},
-					},
-					RequestID: "2",
-					Timestamp: 2,
-				},
-				{
-					Msg: &cvmsgspb.CronScriptUpdate_UpsertReq{
-						UpsertReq: &cvmsgspb.RegisterOrUpdateCronScriptRequest{
-							Script: &cvmsgspb.CronScript{
-								ID:         utils.ProtoFromUUIDStrOrNil("223e4567-e89b-12d3-a456-426655440004"),
-								Script:     "test script 2",
-								Configs:    "config3",
-								FrequencyS: 123,
-							},
-						},
-					},
-					RequestID: "3",
-					Timestamp: 3,
-				},
-				{
-					Msg: &cvmsgspb.CronScriptUpdate_DeleteReq{
-						DeleteReq: &cvmsgspb.DeleteCronScriptRequest{
-							ScriptID: utils.ProtoFromUUIDStrOrNil("223e4567-e89b-12d3-a456-426655440003"),
-						},
-					},
-					RequestID: "4",
-					Timestamp: 4,
-				},
-				{
-					Msg: &cvmsgspb.CronScriptUpdate_UpsertReq{
-						UpsertReq: &cvmsgspb.RegisterOrUpdateCronScriptRequest{
-							Script: &cvmsgspb.CronScript{
-								ID:         utils.ProtoFromUUIDStrOrNil("223e4567-e89b-12d3-a456-426655440003"),
-								Script:     "test script 2",
-								Configs:    "config3",
-								FrequencyS: 123,
-							},
-						},
-					},
-					RequestID: "5",
-					Timestamp: 2,
-				},
-			},
-			expectedScripts: map[string]*cvmsgspb.CronScript{
-				"223e4567-e89b-12d3-a456-426655440002": {
-					ID:         utils.ProtoFromUUIDStrOrNil("223e4567-e89b-12d3-a456-426655440002"),
-					Script:     "test script 2",
-					Configs:    "config3",
-					FrequencyS: 123,
-				},
-				"223e4567-e89b-12d3-a456-426655440004": {
-					ID:         utils.ProtoFromUUIDStrOrNil("223e4567-e89b-12d3-a456-426655440004"),
-					Script:     "test script 2",
-					Configs:    "config3",
-					FrequencyS: 123,
 				},
 			},
 		},
@@ -658,153 +262,159 @@ func TestScriptRunner_SyncScripts(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			nc, natsCleanup := testingutils.MustStartTestNATS(t)
-			defer natsCleanup()
+			ctrl := gomock.NewController(t)
+			mvsExecuteScriptClient := mock_vizierpb.NewMockVizierService_ExecuteScriptClient(ctrl)
+			mvsExecuteScriptClient.EXPECT().
+				Recv().
+				Return(nil, io.EOF).
+				Times(1)
 
-			initialScripts := make(map[uuid.UUID]*cvmsgspb.CronScript)
-			for k, v := range test.persistedScripts {
-				initialScripts[uuid.FromStringOrNil(k)] = v
-			}
+			scriptExecuted := make(chan struct{}, 1)
+			mvs := mock_vizierpb.NewMockVizierServiceClient(ctrl)
+			mvs.EXPECT().
+				ExecuteScript(
+					gomock.Not(gomock.Nil()),
+					NewCustomMatcher(
+						"an ExecuteScriptRequest with the proper QueryName amd QueryStr",
+						func(req *vizierpb.ExecuteScriptRequest) bool {
+							return req.GetQueryName() == "cron_"+scriptID && req.GetQueryStr() == test.queryStr
+						},
+					),
+				).
+				Do(func(_ context.Context, _ *vizierpb.ExecuteScriptRequest) { scriptExecuted <- struct{}{} }).
+				Return(mvsExecuteScriptClient, nil).
+				Times(1)
 
-			fcs := &fakeCronStore{scripts: initialScripts}
-			fvs := &fakeVizierServiceClient{err: errors.New("not implemented")}
-			sr, err := New(nc, fcs, fvs, "test")
-			require.NoError(t, err)
-
-			var wg sync.WaitGroup
-			wg.Add(len(test.updates))
-
-			// Subscribe to request channel.
-			mdSub, err := nc.Subscribe(CronScriptChecksumRequestChannel, func(msg *nats.Msg) {
-				v2cMsg := &cvmsgspb.V2CMessage{}
-				err := proto.Unmarshal(msg.Data, v2cMsg)
-				require.NoError(t, err)
-				req := &cvmsgspb.GetCronScriptsChecksumRequest{}
-				err = types.UnmarshalAny(v2cMsg.Msg, req)
-				require.NoError(t, err)
-				topic := req.Topic
-				checksum, err := scripts.ChecksumFromScriptMap(test.cloudScripts)
-				require.NoError(t, err)
-				resp := &cvmsgspb.GetCronScriptsChecksumResponse{
-					Checksum: checksum,
-				}
-				anyMsg, err := types.MarshalAny(resp)
-				require.NoError(t, err)
-				c2vMsg := cvmsgspb.C2VMessage{
-					Msg: anyMsg,
-				}
-				b, err := c2vMsg.Marshal()
-				require.NoError(t, err)
-
-				err = nc.Publish(fmt.Sprintf("%s:%s", CronScriptChecksumResponseChannel, topic), b)
-				require.NoError(t, err)
-			})
-			defer func() {
-				err = mdSub.Unsubscribe()
-				require.NoError(t, err)
-			}()
-
-			md2Sub, err := nc.Subscribe(GetCronScriptsRequestChannel, func(msg *nats.Msg) {
-				v2cMsg := &cvmsgspb.V2CMessage{}
-				err := proto.Unmarshal(msg.Data, v2cMsg)
-				require.NoError(t, err)
-				req := &cvmsgspb.GetCronScriptsRequest{}
-				err = types.UnmarshalAny(v2cMsg.Msg, req)
-				require.NoError(t, err)
-				topic := req.Topic
-
-				resp := &cvmsgspb.GetCronScriptsResponse{
-					Scripts: test.cloudScripts,
-				}
-				anyMsg, err := types.MarshalAny(resp)
-				require.NoError(t, err)
-				c2vMsg := cvmsgspb.C2VMessage{
-					Msg: anyMsg,
-				}
-				b, err := c2vMsg.Marshal()
-				require.NoError(t, err)
-
-				err = nc.Publish(fmt.Sprintf("%s:%s", GetCronScriptsResponseChannel, topic), b)
-				require.NoError(t, err)
-			})
-			defer func() {
-				err = md2Sub.Unsubscribe()
-				require.NoError(t, err)
-			}()
-
-			for _, u := range test.updates {
-				md3Sub, err := nc.Subscribe(fmt.Sprintf("%s:%s", CronScriptUpdatesResponseChannel, u.RequestID), func(msg *nats.Msg) {
-					wg.Done()
-				})
-				defer func() {
-					err = md3Sub.Unsubscribe()
-					require.NoError(t, err)
+			fcs := &fakeCronStore{scripts: map[uuid.UUID]*cvmsgspb.CronScript{}}
+			source := func(_ context.Context, updateCb func(*cvmsgspb.CronScriptUpdate)) (map[string]*cvmsgspb.CronScript, func(), error) {
+				go func() {
+					for _, update := range test.updates {
+						updateCb(update)
+					}
 				}()
-
-				anyMsg, err := types.MarshalAny(u)
-				require.NoError(t, err)
-				c2vMsg := cvmsgspb.C2VMessage{
-					Msg: anyMsg,
-				}
-				b, err := c2vMsg.Marshal()
-				require.NoError(t, err)
-				err = nc.Publish(CronScriptUpdatesChannel, b)
+				return nil, func() {}, nil
 			}
+			sr := New(fcs, mvs, "test", source)
+			defer sr.Stop()
 
 			go func() {
-				err = sr.SyncScripts()
-				require.NoError(t, err)
+				require.NoError(t, sr.SyncScripts())
 			}()
-			wg.Wait()
-			assert.Equal(t, len(test.expectedScripts), len(fcs.scripts))
-			for k, v := range test.expectedScripts {
-				val, ok := fcs.scripts[uuid.FromStringOrNil(k)]
-				assert.True(t, ok)
-				assert.Equal(t, v, val)
-			}
 
-			assert.Equal(t, len(test.expectedScripts), len(sr.runnerMap))
-			for k, v := range test.expectedScripts {
-				val, ok := sr.runnerMap[uuid.FromStringOrNil(k)]
-				assert.True(t, ok)
-				assert.Equal(t, v, val.cronScript)
-			}
+			requireReceiveWithin(t, scriptExecuted, 10*time.Second)
 		})
 	}
 }
 
-type fakeExecuteScriptClient struct {
-	// The error to send if not nil. The client does not send responses if this is not nil.
-	err       error
-	responses []*vizierpb.ExecuteScriptResponse
-	responseI int
-	grpc.ClientStream
-}
-
-func (es *fakeExecuteScriptClient) Recv() (*vizierpb.ExecuteScriptResponse, error) {
-	if es.err != nil {
-		return nil, es.err
+func TestScriptRunner_ScriptDeletes(t *testing.T) {
+	const scriptID = "223e4567-e89b-12d3-a456-426655440002"
+	const nonExistentScriptID = "223e4567-e89b-12d3-a456-426655440001"
+	tests := []struct {
+		name     string
+		queryStr string
+		updates  []*cvmsgspb.CronScriptUpdate
+	}{
+		{
+			name: "tracks deletes to cron scripts",
+			updates: []*cvmsgspb.CronScriptUpdate{
+				{
+					Msg: &cvmsgspb.CronScriptUpdate_DeleteReq{
+						DeleteReq: &cvmsgspb.DeleteCronScriptRequest{
+							ScriptID: utils.ProtoFromUUIDStrOrNil(scriptID),
+						},
+					},
+					Timestamp: 1,
+				},
+			},
+		},
+		{
+			name: "can delete non-existent runners",
+			updates: []*cvmsgspb.CronScriptUpdate{
+				{
+					Msg: &cvmsgspb.CronScriptUpdate_DeleteReq{
+						DeleteReq: &cvmsgspb.DeleteCronScriptRequest{
+							ScriptID: utils.ProtoFromUUIDStrOrNil(nonExistentScriptID),
+						},
+					},
+					Timestamp: 1,
+				},
+				{
+					Msg: &cvmsgspb.CronScriptUpdate_DeleteReq{
+						DeleteReq: &cvmsgspb.DeleteCronScriptRequest{
+							ScriptID: utils.ProtoFromUUIDStrOrNil(scriptID),
+						},
+					},
+					Timestamp: 1,
+				},
+			},
+		},
+		{
+			name: "discards updates after deletes",
+			updates: []*cvmsgspb.CronScriptUpdate{
+				{
+					Msg: &cvmsgspb.CronScriptUpdate_DeleteReq{
+						DeleteReq: &cvmsgspb.DeleteCronScriptRequest{
+							ScriptID: utils.ProtoFromUUIDStrOrNil(scriptID),
+						},
+					},
+					Timestamp: 2,
+				},
+				{
+					Msg: &cvmsgspb.CronScriptUpdate_UpsertReq{
+						UpsertReq: &cvmsgspb.RegisterOrUpdateCronScriptRequest{
+							Script: &cvmsgspb.CronScript{
+								ID:         utils.ProtoFromUUIDStrOrNil(scriptID),
+								Script:     "updated script",
+								Configs:    "otelEndpointConfig: {url: example.com}",
+								FrequencyS: 1,
+							},
+						},
+					},
+					Timestamp: 1,
+				},
+			},
+		},
 	}
 
-	resp := es.responses[es.responseI]
-	es.responseI++
-	return resp, nil
-}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			mvs := mock_vizierpb.NewMockVizierServiceClient(ctrl)
+			scriptExecuted := make(chan struct{}, 1)
+			mvs.EXPECT().
+				ExecuteScript(
+					gomock.Any(),
+					gomock.Any(),
+				).
+				Do(func(_ context.Context, _ *vizierpb.ExecuteScriptRequest) { scriptExecuted <- struct{}{} }).
+				Times(0)
 
-type fakeVizierServiceClient struct {
-	responses []*vizierpb.ExecuteScriptResponse
-	err       error
-}
+			fcs := &fakeCronStore{scripts: map[uuid.UUID]*cvmsgspb.CronScript{}}
+			source := func(_ context.Context, updateCb func(*cvmsgspb.CronScriptUpdate)) (map[string]*cvmsgspb.CronScript, func(), error) {
+				go func() {
+					for _, update := range test.updates {
+						updateCb(update)
+					}
+				}()
+				return map[string]*cvmsgspb.CronScript{
+					scriptID: {
+						ID:         utils.ProtoFromUUIDStrOrNil(scriptID),
+						Script:     "initial script",
+						Configs:    "otelEndpointConfig: {url: example.com}",
+						FrequencyS: 1,
+					},
+				}, func() {}, nil
+			}
+			sr := New(fcs, mvs, "test", source)
+			defer sr.Stop()
 
-func (vs *fakeVizierServiceClient) ExecuteScript(ctx context.Context, in *vizierpb.ExecuteScriptRequest, opts ...grpc.CallOption) (vizierpb.VizierService_ExecuteScriptClient, error) {
-	return &fakeExecuteScriptClient{responses: vs.responses, err: vs.err}, nil
-}
-func (vs *fakeVizierServiceClient) HealthCheck(ctx context.Context, in *vizierpb.HealthCheckRequest, opts ...grpc.CallOption) (vizierpb.VizierService_HealthCheckClient, error) {
-	return nil, errors.New("Not implemented")
-}
+			go func() {
+				require.NoError(t, sr.SyncScripts())
+			}()
 
-func (vs *fakeVizierServiceClient) GenerateOTelScript(ctx context.Context, req *vizierpb.GenerateOTelScriptRequest, opts ...grpc.CallOption) (*vizierpb.GenerateOTelScriptResponse, error) {
-	return nil, errors.New("Not implemented")
+			requireNoReceive(t, scriptExecuted, 1100*time.Millisecond)
+		})
+	}
 }
 
 func TestScriptRunner_StoreResults(t *testing.T) {
@@ -928,26 +538,23 @@ func TestScriptRunner_StoreResults(t *testing.T) {
 			script := &cvmsgspb.CronScript{
 				ID:         utils.ProtoFromUUIDStrOrNil("223e4567-e89b-12d3-a456-426655440000"),
 				Script:     "px.display()",
-				Configs:    "config1",
+				Configs:    "otelEndpointConfig: {url: example.com}",
 				FrequencyS: 1,
 			}
 
 			id := uuid.FromStringOrNil("223e4567-e89b-12d3-a456-426655440000")
 			fvs := &fakeVizierServiceClient{responses: test.execScriptResponses, err: test.err}
-			runner := newRunner(script, fvs, "test", id, fcs)
-			runner.start()
+			Runner := newRunner(script, fvs, "test", id, fcs)
+			Runner.start()
 
-			var result *metadatapb.RecordExecutionResultRequest
-			select {
-			case result = <-receivedResultRequestCh:
-			case <-time.After(time.Second * 10):
-			}
-			runner.stop()
+			result := requireReceiveWithin(t, receivedResultRequestCh, 10*time.Second)
+
+			Runner.stop()
 			require.NotNil(t, result, "Failed to receive a valid result")
 
-			assert.Equal(t, utils.ProtoFromUUIDStrOrNil("223e4567-e89b-12d3-a456-426655440000"), result.ScriptID)
-			assert.Equal(t, test.expectedExecutionResult.GetError(), result.GetError())
-			assert.Equal(t, test.expectedExecutionResult.GetExecutionStats(), result.GetExecutionStats())
+			require.Equal(t, utils.ProtoFromUUIDStrOrNil("223e4567-e89b-12d3-a456-426655440000"), result.ScriptID)
+			require.Equal(t, test.expectedExecutionResult.GetError(), result.GetError())
+			require.Equal(t, test.expectedExecutionResult.GetExecutionStats(), result.GetExecutionStats())
 		})
 	}
 }

--- a/src/vizier/services/query_broker/script_runner/script_source.go
+++ b/src/vizier/services/query_broker/script_runner/script_source.go
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2018- The Pixie Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package scriptrunner
+
+import (
+	"context"
+
+	"github.com/nats-io/nats.go"
+	log "github.com/sirupsen/logrus"
+	"k8s.io/client-go/rest"
+	"px.dev/pixie/src/shared/cvmsgspb"
+	"px.dev/pixie/src/utils/shared/k8s"
+	"px.dev/pixie/src/vizier/services/metadata/metadatapb"
+)
+
+const (
+	CloudSourceName     = "cloud"
+	ConfigMapSourceName = "configmaps"
+)
+
+var DefaultSources = []string{CloudSourceName}
+
+// A Source provides an initial set of cron scripts and sends incremental updates to that set
+type Source func(ctx context.Context, updateCb func(*cvmsgspb.CronScriptUpdate)) (initial map[string]*cvmsgspb.CronScript, unsubscribe func(), err error)
+
+// Sources initializes multiple sources based on the set of sourceNames provided.
+func Sources(nc *nats.Conn, csClient metadatapb.CronScriptStoreServiceClient, signingKey string, namespace string, sourceNames []string) []Source {
+	var sources []Source
+	for _, selectedName := range sourceNames {
+		switch selectedName {
+		case CloudSourceName:
+			sources = append(sources, CloudSource(nc, csClient, signingKey))
+		case ConfigMapSourceName:
+			kubeConfig, err := rest.InClusterConfig()
+			if err != nil {
+				log.WithError(err).Fatal("Unable to get incluster kubeconfig")
+			}
+			client := k8s.GetClientset(kubeConfig).CoreV1().ConfigMaps(namespace)
+			sources = append(sources, ConfigMapSource(client))
+		default:
+			log.Errorf(`Unknown source "%s"`, selectedName)
+		}
+	}
+	return sources
+}


### PR DESCRIPTION
Summary: For our usage of Pixie, it's convenient to exclude Pixie's dependency on the control plane. This commit allows the query broker:
1. to load cron scripts from config maps in the same namespace
2. to turn on and off loading cron scripts from the cloud or config maps

Type of change: /kind feature

Changes: This commit implements the functionality described above.

* added a `scriptrunner.Source` type that encapsulates how cron scripts are initialized/updated.
* moved existing logic for fetching cron scripts to `scriptrunner.CloudSource`
* added `scriptrunner.ConfigMapSource`
* Modified `scriptrunner.ScriptRunner` to use `scriptrunner.Source`s.
* Added a configuration flag (`--cron_script_sources` or or `PL_CRON_SCRIPT_SOURCES`) that allows a customer to choose which sources cron scripts can be loaded from. By default, it only loads cron scripts from the control plane. If you wanted to use both, for example, you could set `PL_CRON_SCRIPT_SOURCES="cloud configmaps"`.
* Moved many of the fakes/mocks/test helpers to `helper_test.go`


Test Plan: All of these changes have been tested at the unit level in addition to manual testing in all relevant configurations. We did our manual testing on GKE, EKS, and AKS with Kubernetes version 1.25. We don't anticipate other Kubernetes platforms or versions to be a problem since the config map API is stable and consistent across those dimensions. Moving the logic to load scripts from the control plane was probably the riskiest change and might warrant some extra attention.